### PR TITLE
Update detect_video and remove deprecation warning for hog features

### DIFF
--- a/feat/detector.py
+++ b/feat/detector.py
@@ -920,7 +920,7 @@ class Detector(object):
         batch_size=5,
         outputFname=None,
         skip_frames=1,
-        verbose=False,
+        verbose=True,
         singleframe4error=False,
     ):
         """Detects FEX from a video file.
@@ -949,12 +949,12 @@ class Detector(object):
 
         counter = 0
         frame_got = True
-        if verbose:
-            print("Processing video.")
         #  single core
         concat_frame = None
 
-        with tqdm(desc="Progress", total=length, leave=True) as pbar:
+        with tqdm(
+            desc="Progress", total=length, leave=True, disable=not verbose
+        ) as pbar:
             while True:
                 frame_got, frame = cap.read()
                 pbar.update(1)

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -606,7 +606,7 @@ class Detector(object):
             pixels_per_cell=pixels_per_cell,
             cells_per_block=cells_per_block,
             visualize=visualize,
-            multichannel=True,
+            channel_axis=2,
         )
         if visualize:
             return (hog_output[0], hog_output[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ torch
 torchvision
 scikit-image>=0.18.0rc1
 joblib
+tqdm


### PR DESCRIPTION
1. `hog` feature used the deprecated parameter `multichannel=True`. Replace with `channel_axis=2` to indicate the correct color channel information.

2. `detect_video` enhance user feedback during processing
- add `tqdm` as a package requirement (no specific version)
- add a `tqdm` progress bar during `detect_video` to show the current video progressing state (can be disabled with `verbose=False`)
- change the default behavior of the `verbose` parameter to `True` to always display the progress bar

`pytest` ran without problems.