### PR TITLE
add m1 testing to github action runners

### DIFF
--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         # OSs to test
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, osx-arm64, windows-latest]
         # Python versions to test
         python-version: [3.7, 3.8, 3.9]
         # By default everything should pass for the workflow to pass

--- a/.github/workflows/tests_on_pr.yml
+++ b/.github/workflows/tests_on_pr.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         # OSs to test
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, osx-arm64, windows-latest]
         # Python versions to test
         python-version: [3.7, 3.8, 3.9]
         # By default everything should pass for the workflow to pass


### PR DESCRIPTION
It looks like github actions now supports [m1 runners](https://github.com/github/roadmap/issues/507), let's add this to our testing suite.