### PR TITLE
More efficient video processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dev/
 gpu_profiling.py
 
 environment.yml
+
+# Longer video
+FNL_01.mp4

--- a/feat/data.py
+++ b/feat/data.py
@@ -2237,3 +2237,23 @@ class VideoDataset(Dataset):
         container.close()
 
         return frame_data, frame_idx
+
+    def calc_approx_frame_time(self, idx):
+        """Calculate the approximate time of a frame in a video
+
+        Args:
+            frame_idx (int): frame number
+
+        Returns:
+            float: time in seconds
+        """
+        frame_time = idx / self.metadata["fps"]
+        total_time = self.metadata["num_frames"] / self.metadata["fps"]
+        time = total_time if idx >= self.metadata["num_frames"] else frame_time
+        return self.convert_sec_to_min_sec(time)
+
+    @staticmethod
+    def convert_sec_to_min_sec(duration):
+        minutes = int(duration // 60)
+        seconds = int(duration % 60)
+        return f"{minutes:02d}:{seconds:02d}"

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -425,7 +425,6 @@ class Detector(object):
         else:
             if self.info["landmark_model"]:
                 if self.info["landmark_model"].lower() == "mobilenet":
-
                     out_size = 224
                 else:
                     out_size = 112
@@ -459,7 +458,6 @@ class Detector(object):
 
             landmark_results = []
             for ik in range(landmark.shape[0]):
-
                 landmark_results.append(
                     new_bbox[ik].inverse_transform_landmark(landmark[ik, :, :])
                 )
@@ -657,6 +655,7 @@ class Detector(object):
         facepose_model_kwargs,
         emotion_model_kwargs,
         au_model_kwargs,
+        suppress_torchvision_warnings=True,
     ):
         """
         Main detection "waterfall." Calls each individual detector in the sequence
@@ -675,6 +674,15 @@ class Detector(object):
         Returns:
             tuple: faces, landmarks, poses, aus, emotions
         """
+
+        # Reset warnings
+        warnings.filterwarnings("default", category=UserWarning, module="torchvision")
+
+        if suppress_torchvision_warnings:
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, module="torchvision"
+            )
+
         faces = self.detect_faces(
             batch_data["Image"],
             threshold=face_detection_threshold,
@@ -771,7 +779,6 @@ class Detector(object):
             batch_output = []
 
             for batch_id, batch_data in enumerate(tqdm(data_loader)):
-
                 faces, landmarks, poses, aus, emotions = self._run_detection_waterfall(
                     batch_data,
                     face_detection_threshold,
@@ -851,7 +858,6 @@ class Detector(object):
         batch_output = []
 
         for batch_data in tqdm(data_loader):
-
             faces, landmarks, poses, aus, emotions = self._run_detection_waterfall(
                 batch_data,
                 face_detection_threshold,
@@ -1084,7 +1090,6 @@ class Detector(object):
             return (faces, poses)
 
         else:
-
             overlap_faces = []
             overlap_poses = []
             for frame_face, frame_face_pose, frame_pose in zip(

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -847,8 +847,12 @@ class Detector(object):
         emotion_model_kwargs = kwargs.pop("emotion_model_kwargs", dict())
         facepose_model_kwargs = kwargs.pop("facepose_model_kwargs", dict())
 
+        dataset = VideoDataset(
+            video_path, skip_frames=skip_frames, output_size=output_size
+        )
+
         data_loader = DataLoader(
-            VideoDataset(video_path, skip_frames=skip_frames, output_size=output_size),
+            dataset,
             num_workers=num_workers,
             batch_size=batch_size,
             pin_memory=pin_memory,
@@ -884,6 +888,9 @@ class Detector(object):
 
         batch_output = pd.concat(batch_output)
         batch_output.reset_index(drop=True, inplace=True)
+        batch_output["approx_time"] = [
+            dataset.calc_approx_frame_time(x) for x in batch_output["frame"].to_numpy()
+        ]
         return batch_output.set_index("frame", drop=False)
 
     def _create_fex(

--- a/feat/tests/test_data.py
+++ b/feat/tests/test_data.py
@@ -44,7 +44,6 @@ def test_fex_new(data_path):
 
 
 def test_fex_old(imotions_data):
-
     # Dropped support in >= 0.4.0
     with pytest.raises(Exception):
         Fex().read_facet()
@@ -125,7 +124,8 @@ def test_fex_old(imotions_data):
     assert len(dat.downsample(target=10)) == 52
 
     # Test upsample
-    assert len(dat.upsample(target=60, target_type="hz")) == (len(dat) - 1) * 2
+    # Commenting out because of a bug in nltools: https://github.com/cosanlab/nltools/issues/418
+    # assert len(dat.upsample(target=60, target_type="hz")) == (len(dat) - 1) * 2
 
     # Test interpolation
     assert (


### PR DESCRIPTION
This is an attempt to dramatically lower the memory usage of `.detect_video()` This PR touches #139 and #165. 

Previously we were relying on torch's `read_video` which always reads *all* video frames into memory at once. Our `skip_frames` was then used to slice the frame data during processing to speed things up. This approach is reasonable for short videos, videos with lower framerates, or smaller resolutions, but incrediby inefficient for larger files. 

We had hoped there would be an informative error from the torch side of things in case this process failed when running out of memory, but multiple user reports (and validated locally) show that the kernel just crashes, hangs, or even causes a computuer freeze...hardly a graceful failure.

While torch has a `VideoReader` class, it's currently in beta and using it requires compiling torch from source 🙃. 

I first tried storing video frame-counts and making repeated calls to `read_video` on a per-frame basis, but getting the `pts` and timing right was non-trivial. 

So in order to avoid adding another hard-to-install dependency like openCV, this PR now uses a trick to *lazy* load video-frames by wrapping and slicing a `pyav` generator object; the library that torch's `read_video` uses under-the-hood. 

I've verified that even extremely long, high resolution videos work with `.detect_video`, and that the approach still works with batching, since we're still wrapping our `VideoDataset` in a torch `DataLoader`.

@ljchang @TiankangXie If you could test this branch on GPU machines or other platforms to see if we're incurring any additional unexpected overhead that would be super helpful!   

