### PR TITLE
[WIP] Interactive visualization of detectors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
         "docs/**/*.csv": true,
         "docs/**/*.mp4": true
     },
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "none",
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/feat/data.py
+++ b/feat/data.py
@@ -28,8 +28,21 @@ from torch import swapaxes
 from feat.transforms import Rescale
 from feat.utils.io import read_feat, read_openface
 from feat.utils.stats import wavelet, calc_hist_auc
-from feat.plotting import plot_face, draw_lineface, draw_facepose, load_viz_model
+from feat.plotting import (
+    plot_face,
+    draw_lineface,
+    draw_facepose,
+    load_viz_model,
+    face_part_path,
+    draw_plotly_landmark,
+    face_polygon_svg,
+    draw_plotly_au,
+    draw_plotly_pose,
+    emotion_annotation_position,
+)
 from feat.pretrained import AU_LANDMARK_MAP
+from feat.utils import flatten_list
+from feat.utils.io import load_pil_img
 from nilearn.signal import clean
 from scipy.signal import convolve
 from scipy.stats import ttest_1samp, ttest_ind
@@ -42,6 +55,7 @@ from PIL import Image
 import logging
 import av
 from itertools import islice
+import plotly.graph_objects as go
 
 __all__ = [
     "FexSeries",
@@ -1646,197 +1660,882 @@ class Fex(DataFrame):
         gaze = None if isinstance(gaze, bool) else gaze
         return au, gaze, muscles, model
 
-    def plot_detections(
-        self,
-        faces="landmarks",
-        faceboxes=True,
-        muscles=False,
-        poses=False,
-        gazes=False,
-        add_titles=True,
-        au_barplot=True,
-        emotion_barplot=True,
-        plot_original_image=True,
-    ):
-        """
-        Plots detection results by Feat. Can control plotting of face, AU barplot and
-        Emotion barplot. The faces kwarg controls whether facial landmarks are draw on
-        top of input images or whether faces are visualized using Py-Feat's AU
-        visualization model using detected AUs. If detection was performed on a video an
-        faces = 'landmarks', only an outline of the face will be draw without loading
-        the underlying vidoe frame to save memory.
+
+def plot_singleframe_detections(
+    self,
+    image_opacity=0.9,
+    facebox_color="cyan",
+    facebox_width=3,
+    pose_width=2,
+    landmark_color="white",
+    landmark_width=2,
+    emotions_position="right",
+    emotions_opacity=0.9,
+    emotions_color="pink",
+    emotions_size=12,
+    au_heatmap_resolution=1000,
+    au_opacity=0.9,
+    au_cmap="Blues",
+    *args,
+    **kwargs,
+):
+    """
+    Function to generate interactive plotly figure to interactively visualize py-feat detectors on a single image frame.
+
+    Args:
+        image_opacity (float): opacity of image overlay (default=.9)
+        emotions_position (str): position around facebox to plot emotion annotations. default='right'
+        emotions_opacity (float): opacity of emotion annotation text (default=.9)
+        emotions_color (str): color of emotion annotation text (default='pink')
+        emotions_size (int): size of emotion annotations (default=14)
+        frame_duration (int): duration in milliseconds to play each frame if plotting multiple frames (default=1000)
+        facebox_color (str): color of facebox bounding box (default="cyan")
+        facebox_width (int): line width of facebox bounding box (default=3)
+        pose_width (int): line width of pose rotation plot (default=2)
+        landmark_color (str): color of landmark detectors (default="white")
+        landmark_width (int): line width of landmark detectors (default=2)
+        au_cmap (str): colormap to use for AU heatmap (default='Blues')
+        au_heatmap_resolution (int): resolution of heatmap values (default=1000)
+        au_opacity (float): opacity of AU heatmaps (default=0.9)
+
+    Returns:
+        a plotly figure instance
+    """
+
+    n_frames = len(self["frame"].unique())
+
+    if n_frames > 1:
+        raise ValueError(
+            "This function can only plot a single frame. Try using plot_multipleframe_detections() instead."
+        )
+
+    # Initialize Image
+    frame_id = 0
+    frame_fex = self.query("frame==@frame_id")
+    frame_img = load_pil_img(frame_fex["input"].unique()[0], frame_id)
+    img_width = frame_img.width
+    img_height = frame_img.height
+
+    # Create figure
+    fig = go.Figure()
+
+    # Add invisible scatter trace.
+    # This trace is added to help the autoresize logic work.
+    fig.add_trace(
+        go.Scatter(
+            x=[0, img_width],
+            y=[0, img_height],
+            mode="markers",
+            marker_opacity=0,
+        )
+    )
+
+    # Add image
+    fig.add_layout_image(
+        dict(
+            x=0,
+            sizex=img_width,
+            y=img_height,
+            sizey=img_height,
+            xref="x",
+            yref="y",
+            opacity=image_opacity,
+            layer="below",
+            sizing="stretch",
+            source=frame_img,
+        )
+    )
+
+    # Add Face Bounding Box
+    faceboxes_path = [
+        dict(
+            type="rect",
+            x0=row["FaceRectX"],
+            y0=img_height - row["FaceRectY"],
+            x1=row["FaceRectX"] + row["FaceRectWidth"],
+            y1=img_height - row["FaceRectY"] - row["FaceRectHeight"],
+            line=dict(color=facebox_color, width=facebox_width),
+        )
+        for i, row in frame_fex.iterrows()
+    ]
+
+    # Add Landmarks
+    landmarks_path = [
+        draw_plotly_landmark(
+            row, img_height, fig, line_color=landmark_color, line_width=landmark_width
+        )
+        for i, row in frame_fex.iterrows()
+    ]
+
+    # Add Pose
+    poses_path = flatten_list(
+        [
+            draw_plotly_pose(row, img_height, fig, line_width=pose_width)
+            for i, row in frame_fex.iterrows()
+        ]
+    )
+
+    # Add Emotions
+    emotions_annotations = []
+    for i, row in frame_fex.iterrows():
+        emotion_dict = (
+            row[
+                [
+                    "anger",
+                    "disgust",
+                    "fear",
+                    "happiness",
+                    "sadness",
+                    "surprise",
+                    "neutral",
+                ]
+            ]
+            .sort_values(ascending=False)
+            .to_dict()
+        )
+
+        x_position, y_position, align, valign = emotion_annotation_position(
+            row,
+            img_height,
+            img_width,
+            emotions_size=emotions_size,
+            emotions_position=emotions_position,
+        )
+
+        emotion_text = ""
+        for emotion in emotion_dict:
+            emotion_text += f"{emotion}: <i>{emotion_dict[emotion]:.2f}</i><br>"
+
+        emotions_annotations.append(
+            dict(
+                text=emotion_text,
+                x=x_position,
+                y=y_position,
+                opacity=emotions_opacity,
+                showarrow=False,
+                align=align,
+                valign=valign,
+                font=dict(color=emotions_color, size=emotions_size),
+            )
+        )
+
+    # Add AU Heatmaps
+    aus_path = flatten_list(
+        [
+            draw_plotly_au(
+                row,
+                img_height,
+                fig,
+                cmap=au_cmap,
+                au_opacity=au_opacity,
+                heatmap_resolution=au_heatmap_resolution,
+            )
+            for i, row in frame_fex.iterrows()
+        ]
+    )
+
+    # Configure other layout
+    fig.update_layout(
+        width=img_width,
+        height=img_height,
+        margin={"l": 0, "r": 0, "t": 0, "b": 0},
+    )
+
+    # Configure axes
+    fig.update_xaxes(visible=False, range=[0, img_width])
+
+    fig.update_yaxes(
+        visible=False,
+        range=[0, img_height],
+        scaleanchor="x",  # the scaleanchor attribute ensures that the aspect ratio stays constant
+    )
+
+    # Add a button to the figure
+    fig.update_layout(
+        updatemenus=[
+            dict(
+                type="buttons",
+                direction="left",
+                buttons=list(
+                    [
+                        dict(
+                            method="relayout",
+                            label="Bounding Box",
+                            args=["shapes", faceboxes_path],
+                            args2=["shapes", []],
+                        ),
+                        dict(
+                            method="relayout",
+                            label="Landmarks",
+                            args=["shapes", landmarks_path],
+                            args2=["shapes", []],
+                        ),
+                        dict(
+                            method="relayout",
+                            label="Poses",
+                            args=["shapes", poses_path],
+                            args2=["shapes", []],
+                        ),
+                        dict(
+                            method="relayout",
+                            label="Emotion",
+                            args=["annotations", emotions_annotations],
+                            args2=["annotations", []],
+                        ),
+                        dict(
+                            method="relayout",
+                            label="AU",
+                            args=["shapes", aus_path],
+                            args2=["shapes", []],
+                        ),
+                    ]
+                ),
+                pad={"r": 10, "t": 10},
+                showactive=True,
+                x=0.1,
+                xanchor="left",
+                y=1.12,
+                yanchor="top",
+            )
+        ]
+    )
+
+    # Add annotation
+    fig.update_layout(
+        annotations=[
+            dict(
+                text="Detector:",
+                showarrow=False,
+                x=0,
+                y=1.09,
+                yref="paper",
+                align="left",
+            )
+        ]
+    )
+
+    fig.show()
+    return fig
 
 
-        Args:
-            faces (str, optional): 'landmarks' to draw detected landmarks or 'aus' to
-            generate a face from AU detections using Py-Feat's AU landmark model.
-            Defaults to 'landmarks'.
-            faceboxes (bool, optional): Whether to draw the bounding box around detected
-            faces. Only applies if faces='landmarks'. Defaults to True.
-            muscles (bool, optional): Whether to draw muscles from AU activity. Only
-            applies if faces='aus'. Defaults to False.
-            poses (bool, optional): Whether to draw facial poses. Only applies if
-            faces='landmarks'. Defaults to False.
-            gazes (bool, optional): Whether to draw gaze vectors. Only applies if faces='aus'. Defaults to False.
-            add_titles (bool, optional): Whether to add the file name as a title above
-            the face. Defaults to True.
-            au_barplot (bool, optional): Whether to include a subplot for au detections. Defaults to True.
-            emotion_barplot (bool, optional): Whether to include a subplot for emotion detections. Defaults to True.
+def plot_multipleframes_detections(
+    self,
+    faceboxes=True,
+    landmarks=False,
+    aus=True,
+    poses=False,
+    emotions=False,
+    emotions_position="right",
+    emotions_opacity=0.9,
+    emotions_color="pink",
+    emotions_size=14,
+    frame_duration=1000,
+    facebox_color="cyan",
+    facebox_width=3,
+    pose_width=2,
+    landmark_color="white",
+    landmark_width=2,
+    au_heatmap_resolution=1000,
+    au_opacity=0.9,
+    au_cmap="Blues",
+    *args,
+    **kwargs,
+):
+    """
+    Function to generate interactive plotly figure to visualize py-feat detectors on a series of image frames (e.g., videos).
+
+    Args:
+        faceboxes (bool): will include faceboxes when plotting detector output for multiple frames.
+        landmarks (bool): will include face landmarks when plotting detector output for multiple frames.
+        poses (bool): will include 3 axis line plot indicating x,y,z rotation information when plotting detector output for multiple frames.
+        aus (bool): will include action unit heatmaps when plotting detector output for multiple frames.
+        emotions (bool): will add text annotations indicating probability of discrete emotion when plotting detector output for multiple frames.
+        image_opacity (float): opacity of image overlay (default=.9)
+        emotions_position (str): position around facebox to plot emotion annotations. default='right'
+        emotions_opacity (float): opacity of emotion annotation text (default=.9)
+        emotions_color (str): color of emotion annotation text (default='pink')
+        emotions_size (int): size of emotion annotations (default=14)
+        frame_duration (int): duration in milliseconds to play each frame if plotting multiple frames (default=1000)
+        facebox_color (str): color of facebox bounding box (default="cyan")
+        facebox_width (int): line width of facebox bounding box (default=3)
+        pose_width (int): line width of pose rotation plot (default=2)
+        landmark_color (str): color of landmark detectors (default="white")
+        landmark_width (int): line width of landmark detectors (default=2)
+        au_cmap (str): colormap to use for AU heatmap (default='Blues')
+        au_heatmap_resolution (int): resolution of heatmap values (default=1000)
+        au_opacity (float): opacity of AU heatmaps (default=0.9)
+
+    Returns:
+        a plotly figure instance
+    """
+    n_frames = len(self["frame"].unique())
+
+    if n_frames <= 1:
+        raise ValueError(
+            "This function plots multiple frames. Try using plot_singleframe_detections() instead."
+        )
+
+    # Initialize Image
+    frame_id = 0
+    frame_fex = self.query("frame==@frame_id")
+    frame_img = load_pil_img(frame_fex["input"].unique()[0], frame_id)
+    img_width = frame_img.width
+    img_height = frame_img.height
+
+    # Initialize Figure
+    fig = go.Figure(
+        go.Scatter(
+            x=[0, img_width], y=[0, img_height], mode="markers", marker_opacity=0
+        )
+    )
+    fig.update_layout(
+        xaxis_visible=False, yaxis_visible=False, width=img_width, height=img_height
+    )
+
+    sliders_dict = {
+        "active": 0,
+        "yanchor": "top",
+        "xanchor": "left",
+        "currentvalue": {
+            "font": {"size": 20},
+            "prefix": "Frame:",
+            "visible": True,
+            "xanchor": "right",
+        },
+        "transition": {"duration": 300, "easing": "cubic-in-out"},
+        "pad": {"b": 10, "t": 50},
+        "len": 0.9,
+        "x": 0.1,
+        "y": 0,
+        "steps": [],
+    }
+
+    # Create Frames
+    frames = []
+    for frame_id in self["frame"].unique():
+        # Load new image
+        frame_fex = self.query("frame==@frame_id")
+        frame_img = load_pil_img(frame_fex["input"].unique()[0], frame_id)
+        img_width = frame_img.width
+        img_height = frame_img.height
+
+        # Add detector paths
+        shapes = []
+        if faceboxes:
+            shapes += [
+                dict(
+                    type="rect",
+                    x0=row["FaceRectX"],
+                    y0=img_height - row["FaceRectY"],
+                    x1=row["FaceRectX"] + row["FaceRectWidth"],
+                    y1=img_height - row["FaceRectY"] - row["FaceRectHeight"],
+                    line=dict(color=facebox_color, width=facebox_width),
+                )
+                for i, row in frame_fex.iterrows()
+            ]
+
+        if poses:
+            shapes += flatten_list(
+                [
+                    draw_plotly_pose(row, img_height, fig, line_width=pose_width)
+                    for i, row in frame_fex.iterrows()
+                ]
+            )
+
+        if landmarks:
+            shapes += [
+                draw_plotly_landmark(
+                    row,
+                    img_height,
+                    fig,
+                    line_color=landmark_color,
+                    line_width=landmark_width,
+                )
+                for i, row in frame_fex.iterrows()
+            ]
+
+        if aus:
+            shapes += flatten_list(
+                [
+                    draw_plotly_au(
+                        row,
+                        img_height,
+                        fig,
+                        cmap=au_cmap,
+                        au_opacity=au_opacity,
+                        heatmap_resolution=au_heatmap_resolution,
+                    )
+                    for i, row in frame_fex.iterrows()
+                ]
+            )
+
+        # Add emotion annotations
+        emotions_annotations = []
+        if emotions:
+            for i, row in frame_fex.iterrows():
+                emotion_dict = (
+                    row[
+                        [
+                            "anger",
+                            "disgust",
+                            "fear",
+                            "happiness",
+                            "sadness",
+                            "surprise",
+                            "neutral",
+                        ]
+                    ]
+                    .sort_values(ascending=False)
+                    .to_dict()
+                )
+
+                x_position, y_position, align, valign = emotion_annotation_position(
+                    row,
+                    img_height,
+                    img_width,
+                    emotions_size=emotions_size,
+                    emotions_position=emotions_position,
+                )
+
+                emotion_text = ""
+                for emotion in emotion_dict:
+                    emotion_text += f"{emotion}: <i>{emotion_dict[emotion]:.2f}</i><br>"
+
+                emotions_annotations.append(
+                    dict(
+                        text=emotion_text,
+                        x=x_position,
+                        y=y_position,
+                        opacity=emotions_opacity,
+                        showarrow=False,
+                        align=align,
+                        valign=valign,
+                        font=dict(color=emotions_color, size=emotions_size),
+                    )
+                )
+
+        sliders_dict["steps"].append(
+            {
+                "args": [
+                    [frame_id],
+                    {
+                        "frame": {"duration": frame_duration, "redraw": True},
+                        "mode": "immediate",
+                        "transition": {"duration": frame_duration},
+                    },
+                ],
+                "label": str(frame_id),
+                "method": "animate",
+            }
+        )
+        frame = go.Frame(
+            data=[],
+            layout=dict(
+                images=[
+                    dict(
+                        source=frame_img,
+                        opacity=0.9,
+                        layer="below",
+                        sizing="stretch",
+                        x=0,
+                        sizex=img_width,
+                        y=img_height,
+                        sizey=img_height,
+                        xref="x",
+                        yref="y",
+                    )
+                ],
+                xaxis_visible=False,
+                yaxis_visible=False,
+                width=img_width,
+                height=img_height,
+                shapes=shapes,
+                annotations=emotions_annotations,
+                updatemenus=[
+                    dict(
+                        buttons=[
+                            dict(
+                                args=[
+                                    None,
+                                    {
+                                        "frame": {
+                                            "duration": frame_duration,
+                                            "redraw": True,
+                                        },
+                                        "fromcurrent": True,
+                                    },
+                                ],
+                                label="Play",
+                                method="animate",
+                            ),
+                            dict(
+                                args=[
+                                    [None],
+                                    {
+                                        "frame": {"duration": 0, "redraw": False},
+                                        "mode": "immediate",
+                                        "transition": {"duration": 0},
+                                    },
+                                ],
+                                label="Pause",
+                                method="animate",
+                            ),
+                        ],
+                        direction="left",
+                        pad={"r": 10, "t": 87},
+                        showactive=True,
+                        type="buttons",
+                        x=0.1,
+                        xanchor="right",
+                        y=0,
+                        yanchor="top",
+                    )
+                ],
+            ),
+            name=str(frame_id),
+        )
+
+        frames.append(frame)
+
+    fig.update(frames=frames)
+    fig.update_layout(
+        updatemenus=[
+            dict(
+                buttons=[
+                    dict(
+                        args=[
+                            None,
+                            {
+                                "frame": {"duration": frame_duration, "redraw": True},
+                                "fromcurrent": True,
+                            },
+                        ],
+                        label="Play",
+                        method="animate",
+                    ),
+                    dict(
+                        args=[
+                            [None],
+                            {
+                                "frame": {"duration": 0, "redraw": True},
+                                "mode": "immediate",
+                                "transition": {"duration": 0},
+                            },
+                        ],
+                        label="Pause",
+                        method="animate",
+                    ),
+                ],
+                direction="left",
+                pad={"r": 10, "t": 87},
+                showactive=False,
+                type="buttons",
+                x=0.1,
+                xanchor="right",
+                y=0,
+                yanchor="top",
+            )
+        ],
+        sliders=[sliders_dict],
+    )
+    fig.show()
+
+    return fig
 
 
-        Returns:
-            list: list of matplotlib figures
-        """
+def plot_detections(
+    self,
+    faceboxes=True,
+    landmarks=True,
+    aus=False,
+    poses=False,
+    emotions=False,
+    emotions_position="right",
+    emotions_opacity=0.9,
+    emotions_color="pink",
+    emotions_size=14,
+    frame_duration=1000,
+    facebox_color="cyan",
+    facebox_width=3,
+    pose_width=2,
+    landmark_color="white",
+    landmark_width=2,
+    au_cmap="Blues",
+    au_heatmap_resolution=1000,
+    au_opacity=0.9,
+    *args,
+    **kwargs,
+):
+    """Plot Py-FEAT detection results using plotly backend. There are currently two different types of plots implemented. For single Frames, uses plot_singleframe_detections() to create an interactive plot where different detector outputs can be toggled on or off.  For multiple frames, uses plot_multipleframes_detections() to create a plotly animation to scroll through multiple frames. However, we currently are unable to interactively toggle on and off the detectors, so the detector output must be prespecified when generating the plot.
 
-        # Plotting logic, eventually refactor me!:
-        # Possible detections:
-        # 1. Single image - single-face
-        # 2. Single image - multi-face
-        # 3. Multi image - single-face per image
-        # 4. Multi image - multi-face per image
-        # 5. Multi image - single and multi-face mix per image
-        # 6. Video - single-face for all frames
-        # 7. Video - multi-face for all frames
-        # 8. Video - single and multi-face mix across frames
+    Args:
+        faceboxes (bool): will include faceboxes when plotting detector output for multiple frames.
+        landmarks (bool): will include face landmarks when plotting detector output for multiple frames.
+        poses (bool): will include 3 axis line plot indicating x,y,z rotation information when plotting detector output for multiple frames.
+        aus (bool): will include action unit heatmaps when plotting detector output for multiple frames.
+        emotions (bool): will add text annotations indicating probability of discrete emotion when plotting detector output for multiple frames.
+        emotions_position (str): position around facebox to plot emotion annotations. default='right'
+        emotions_opacity (float): opacity of emotion annotation text (default=.9)
+        emotions_color (str): color of emotion annotation text (default='pink')
+        emotions_size (int): size of emotion annotations (default=14)
+        frame_duration (int): duration in milliseconds to play each frame if plotting multiple frames (default=1000)
+        facebox_color (str): color of facebox bounding box (default="cyan")
+        facebox_width (int): line width of facebox bounding box (default=3)
+        pose_width (int): line width of pose rotation plot (default=2)
+        landmark_color (str): color of landmark detectors (default="white")
+        landmark_width (int): line width of landmark detectors (default=2)
+        au_cmap (str): colormap to use for AU heatmap (default='Blues')
+        au_heatmap_resolution (int): resolution of heatmap values (default=1000)
+        au_opacity (float): opacity of AU heatmaps (default=0.9)
 
-        sns.set_context("paper", font_scale=2.0)
+    Returns:
+        a plotly figure instance
+    """
 
-        num_subplots = bool(faces) + au_barplot + emotion_barplot
+    n_frames = len(self["frame"].unique())
 
-        all_figs = []
-        for _, frame in enumerate(self.frame.unique()):
-            # Determine figure width based on how many subplots we have
-            f = plt.figure(figsize=(5 * num_subplots, 7))
-            spec = f.add_gridspec(ncols=num_subplots, nrows=1)
-            col_count = 0
-            plot_data = self.query("frame == @frame")
-            face_ax, au_ax, emo_ax = None, None, None
-            if faces is not False:
-                face_ax = f.add_subplot(spec[0, col_count])
-                col_count += 1
-            if au_barplot:
-                au_ax = f.add_subplot(spec[0, col_count])
-                col_count += 1
-            if emotion_barplot:
-                emo_ax = f.add_subplot(spec[0, col_count])
-                col_count += 1
+    if n_frames > 1:
+        plot_single_frame = False
+    else:
+        plot_single_frame = True
 
-            for _, row in plot_data.iterrows():
-                # DRAW LANDMARKS ON IMAGE OR AU FACE
-                if face_ax is not None:
-                    facebox = row[self.facebox_columns].values
+    if plot_single_frame:
+        fig = plot_singleframe_detections(
+            self,
+            facebox_color=facebox_color,
+            facebox_width=facebox_width,
+            pose_width=pose_width,
+            landmark_color=landmark_color,
+            landmark_width=landmark_width,
+            emotions_position=emotions_position,
+            emotions_opacity=emotions_opacity,
+            emotions_color=emotions_color,
+            emotions_size=emotions_size,
+            au_cmap=au_cmap,
+            au_heatmap_resolution=au_heatmap_resolution,
+            au_opacity=au_opacity,
+            *args,
+            **kwargs,
+        )
 
-                    if not faces == "aus" and plot_original_image:
-                        file_extension = os.path.basename(row["input"]).split(".")[-1]
-                        if file_extension.lower() in [
-                            "jpg",
-                            "jpeg",
-                            "png",
-                            "bmp",
-                            "tiff",
-                            "pdf",
-                        ]:
-                            img = read_image(row["input"])
-                        else:
-                            # Ignore UserWarning: The pts_unit 'pts' gives wrong results. Please use
-                            # pts_unit 'sec'. See why it's ok in this issue:
-                            # https://github.com/pytorch/vision/issues/1931
-                            with warnings.catch_warnings():
-                                warnings.simplefilter("ignore", UserWarning)
-                                video, audio, info = read_video(
-                                    row["input"], output_format="TCHW"
-                                )
-                            img = video[row["frame"], :, :]
-                        color = "w"
-                        face_ax.imshow(img.permute([1, 2, 0]))
-                    else:
-                        color = "k"  # drawing lineface but not on photo
+    else:
+        fig = plot_multipleframes_detections(
+            self,
+            faceboxes=faceboxes,
+            landmarks=landmarks,
+            aus=aus,
+            pose=poses,
+            emotions=emotions,
+            emotions_position=emotions_position,
+            emotions_opacity=emotions_opacity,
+            emotions_color=emotions_color,
+            emotions_size=emotions_size,
+            frame_duration=frame_duration,
+            facebox_color=facebox_color,
+            facebox_width=facebox_width,
+            pose_width=pose_width,
+            landmark_color=landmark_color,
+            landmark_width=landmark_width,
+            au_cmap=au_cmap,
+            au_heatmap_resolution=au_heatmap_resolution,
+            au_opacity=au_opacity,
+            *args,
+            **kwargs,
+        )
 
-                    if faceboxes:
-                        rect = Rectangle(
-                            (facebox[0], facebox[1]),
-                            facebox[2],
-                            facebox[3],
-                            linewidth=2,
-                            edgecolor="cyan",
-                            fill=False,
-                        )
-                        face_ax.add_patch(rect)
+    return fig
 
-                    if poses:
-                        face_ax = draw_facepose(
-                            pose=row[self.facepose_columns].values,
-                            facebox=facebox,
-                            ax=face_ax,
-                        )
+    # Deprecated original plot_detections plot using matplotlib backend
 
-                    if faces == "landmarks":
-                        landmark = row[self.landmark_columns].values
-                        currx = landmark[:68]
-                        curry = landmark[68:]
+    # def plot_detections(
+    #     self,
+    #     faces="landmarks",
+    #     faceboxes=True,
+    #     muscles=False,
+    #     poses=False,
+    #     gazes=False,
+    #     add_titles=True,
+    #     au_barplot=True,
+    #     emotion_barplot=True,
+    #     plot_original_image=True,
+    # ):
+    #     """
+    #     Plots detection results by Feat. Can control plotting of face, AU barplot and
+    #     Emotion barplot. The faces kwarg controls whether facial landmarks are draw on
+    #     top of input images or whether faces are visualized using Py-Feat's AU
+    #     visualization model using detected AUs. If detection was performed on a video an
+    #     faces = 'landmarks', only an outline of the face will be draw without loading
+    #     the underlying vidoe frame to save memory.
 
-                        # facelines
-                        face_ax = draw_lineface(
-                            currx, curry, ax=face_ax, color=color, linewidth=3
-                        )
-                        if not plot_original_image:
-                            face_ax.invert_yaxis()
+    #     Args:
+    #         faces (str, optional): 'landmarks' to draw detected landmarks or 'aus' to
+    #         generate a face from AU detections using Py-Feat's AU landmark model.
+    #         Defaults to 'landmarks'.
+    #         faceboxes (bool, optional): Whether to draw the bounding box around detected
+    #         faces. Only applies if faces='landmarks'. Defaults to True.
+    #         muscles (bool, optional): Whether to draw muscles from AU activity. Only
+    #         applies if faces='aus'. Defaults to False.
+    #         poses (bool, optional): Whether to draw facial poses. Only applies if
+    #         faces='landmarks'. Defaults to False.
+    #         gazes (bool, optional): Whether to draw gaze vectors. Only applies if faces='aus'. Defaults to False.
+    #         add_titles (bool, optional): Whether to add the file name as a title above
+    #         the face. Defaults to True.
+    #         au_barplot (bool, optional): Whether to include a subplot for au detections. Defaults to True.
+    #         emotion_barplot (bool, optional): Whether to include a subplot for emotion detections. Defaults to True.
 
-                    elif faces == "aus":
-                        # Generate face from AU landmark model
-                        if any(self.groupby("frame").size() > 1):
-                            raise NotImplementedError(
-                                "Plotting using AU landmark model is not currently supported for detections that contain multiple faces"
-                            )
-                        if muscles:
-                            muscles = {"all": "heatmap"}
-                        else:
-                            muscles = {}
-                        aus, gaze, muscles, model = self._prepare_plot_aus(
-                            row, muscles=muscles, gaze=gazes
-                        )
-                        title = row["input"] if add_titles else None
-                        face_ax = plot_face(
-                            model=model,
-                            au=aus,
-                            gaze=gaze,
-                            ax=face_ax,
-                            muscles=muscles,
-                            title=None,
-                        )
-                    else:
-                        raise ValueError(
-                            f"faces={type(faces)} is not currently supported try ['False','landmarks','aus']."
-                        )
+    #     Returns:
+    #         list: list of matplotlib figures
+    #     """
 
-                    if add_titles:
-                        _ = face_ax.set_title(
-                            "\n".join(wrap(os.path.basename(row["input"]))),
-                            loc="center",
-                            wrap=True,
-                            fontsize=14,
-                        )
+    #     # Plotting logic, eventually refactor me!:
+    #     # Possible detections:
+    #     # 1. Single image - single-face
+    #     # 2. Single image - multi-face
+    #     # 3. Multi image - single-face per image
+    #     # 4. Multi image - multi-face per image
+    #     # 5. Multi image - single and multi-face mix per image
+    #     # 6. Video - single-face for all frames
+    #     # 7. Video - multi-face for all frames
+    #     # 8. Video - single and multi-face mix across frames
 
-                    face_ax.axes.get_xaxis().set_visible(False)
-                    face_ax.axes.get_yaxis().set_visible(False)
+    #     sns.set_context("paper", font_scale=2.0)
 
-            # DRAW AU BARPLOT
-            if au_ax is not None:
-                _ = plot_data.aus.T.plot(kind="barh", ax=au_ax)
-                _ = au_ax.invert_yaxis()
-                _ = au_ax.legend().remove()
-                _ = au_ax.set(xlim=[0, 1.1], title="Action Units")
+    #     num_subplots = bool(faces) + au_barplot + emotion_barplot
 
-            # DRAW EMOTION BARPLOT
-            if emo_ax is not None:
-                _ = plot_data.emotions.T.plot(kind="barh", ax=emo_ax)
-                _ = emo_ax.invert_yaxis()
-                _ = emo_ax.legend().remove()
-                _ = emo_ax.set(xlim=[0, 1.1], title="Emotions")
+    #     all_figs = []
+    #     for _, frame in enumerate(self.frame.unique()):
+    #         # Determine figure width based on how many subplots we have
+    #         f = plt.figure(figsize=(5 * num_subplots, 7))
+    #         spec = f.add_gridspec(ncols=num_subplots, nrows=1)
+    #         col_count = 0
+    #         plot_data = self.query("frame == @frame")
+    #         face_ax, au_ax, emo_ax = None, None, None
+    #         if faces is not False:
+    #             face_ax = f.add_subplot(spec[0, col_count])
+    #             col_count += 1
+    #         if au_barplot:
+    #             au_ax = f.add_subplot(spec[0, col_count])
+    #             col_count += 1
+    #         if emotion_barplot:
+    #             emo_ax = f.add_subplot(spec[0, col_count])
+    #             col_count += 1
 
-            f.tight_layout()
-            all_figs.append(f)
-        return all_figs
+    #         for _, row in plot_data.iterrows():
+    #             # DRAW LANDMARKS ON IMAGE OR AU FACE
+    #             if face_ax is not None:
+    #                 facebox = row[self.facebox_columns].values
+
+    #                 if not faces == "aus" and plot_original_image:
+    #                     file_extension = os.path.basename(row["input"]).split(".")[-1]
+    #                     if file_extension.lower() in [
+    #                         "jpg",
+    #                         "jpeg",
+    #                         "png",
+    #                         "bmp",
+    #                         "tiff",
+    #                         "pdf",
+    #                     ]:
+    #                         img = read_image(row["input"])
+    #                     else:
+    #                         # Ignore UserWarning: The pts_unit 'pts' gives wrong results. Please use
+    #                         # pts_unit 'sec'. See why it's ok in this issue:
+    #                         # https://github.com/pytorch/vision/issues/1931
+    #                         with warnings.catch_warnings():
+    #                             warnings.simplefilter("ignore", UserWarning)
+    #                             video, audio, info = read_video(
+    #                                 row["input"], output_format="TCHW"
+    #                             )
+    #                         img = video[row["frame"], :, :]
+    #                     color = "w"
+    #                     face_ax.imshow(img.permute([1, 2, 0]))
+    #                 else:
+    #                     color = "k"  # drawing lineface but not on photo
+
+    #                 if faceboxes:
+    #                     rect = Rectangle(
+    #                         (facebox[0], facebox[1]),
+    #                         facebox[2],
+    #                         facebox[3],
+    #                         linewidth=2,
+    #                         edgecolor="cyan",
+    #                         fill=False,
+    #                     )
+    #                     face_ax.add_patch(rect)
+
+    #                 if poses:
+    #                     face_ax = draw_facepose(
+    #                         pose=row[self.facepose_columns].values,
+    #                         facebox=facebox,
+    #                         ax=face_ax,
+    #                     )
+
+    #                 if faces == "landmarks":
+    #                     landmark = row[self.landmark_columns].values
+    #                     currx = landmark[:68]
+    #                     curry = landmark[68:]
+
+    #                     # facelines
+    #                     face_ax = draw_lineface(
+    #                         currx, curry, ax=face_ax, color=color, linewidth=3
+    #                     )
+    #                     if not plot_original_image:
+    #                         face_ax.invert_yaxis()
+
+    #                 elif faces == "aus":
+    #                     # Generate face from AU landmark model
+    #                     if any(self.groupby("frame").size() > 1):
+    #                         raise NotImplementedError(
+    #                             "Plotting using AU landmark model is not currently supported for detections that contain multiple faces"
+    #                         )
+    #                     if muscles:
+    #                         muscles = {"all": "heatmap"}
+    #                     else:
+    #                         muscles = {}
+    #                     aus, gaze, muscles, model = self._prepare_plot_aus(
+    #                         row, muscles=muscles, gaze=gazes
+    #                     )
+    #                     title = row["input"] if add_titles else None
+    #                     face_ax = plot_face(
+    #                         model=model,
+    #                         au=aus,
+    #                         gaze=gaze,
+    #                         ax=face_ax,
+    #                         muscles=muscles,
+    #                         title=None,
+    #                     )
+    #                 else:
+    #                     raise ValueError(
+    #                         f"faces={type(faces)} is not currently supported try ['False','landmarks','aus']."
+    #                     )
+
+    #                 if add_titles:
+    #                     _ = face_ax.set_title(
+    #                         "\n".join(wrap(os.path.basename(row["input"]))),
+    #                         loc="center",
+    #                         wrap=True,
+    #                         fontsize=14,
+    #                     )
+
+    #                 face_ax.axes.get_xaxis().set_visible(False)
+    #                 face_ax.axes.get_yaxis().set_visible(False)
+
+    #         # DRAW AU BARPLOT
+    #         if au_ax is not None:
+    #             _ = plot_data.aus.T.plot(kind="barh", ax=au_ax)
+    #             _ = au_ax.invert_yaxis()
+    #             _ = au_ax.legend().remove()
+    #             _ = au_ax.set(xlim=[0, 1.1], title="Action Units")
+
+    #         # DRAW EMOTION BARPLOT
+    #         if emo_ax is not None:
+    #             _ = plot_data.emotions.T.plot(kind="barh", ax=emo_ax)
+    #             _ = emo_ax.invert_yaxis()
+    #             _ = emo_ax.legend().remove()
+    #             _ = emo_ax.set(xlim=[0, 1.1], title="Emotions")
+
+    #         f.tight_layout()
+    #         all_figs.append(f)
+    #     return all_figs
 
     # TODO: turn this into a property using a @property and @sessions.settr decorators
     # Tried it but was running into maximum recursion depth errors. Maybe some

--- a/feat/data.py
+++ b/feat/data.py
@@ -1710,7 +1710,7 @@ class Fex(DataFrame):
             )
 
         # Initialize Image
-        frame_id = 0
+        frame_id = self["frame"].unique()[0]
         frame_fex = self.query("frame==@frame_id")
         frame_img = load_pil_img(frame_fex["input"].unique()[0], frame_id)
         img_width = frame_img.width

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -11,7 +11,6 @@ from sklearn import __version__ as skversion
 from sklearn.preprocessing import PolynomialFeatures, scale
 import matplotlib.pyplot as plt
 from feat.pretrained import AU_LANDMARK_MAP
-from feat.utils.io import get_resource_path
 from math import sin, cos
 import warnings
 import seaborn as sns
@@ -21,6 +20,7 @@ from pathlib import Path
 from PIL import Image
 from textwrap import wrap
 from joblib import load
+from feat.utils import flatten_list
 from feat.utils.io import get_resource_path, download_url
 import json
 

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -34,6 +34,12 @@ __all__ = [
     "imshow",
     "interpolate_aus",
     "animate_face",
+    "face_part_path",
+    "draw_plotly_landmark",
+    "face_polygon_svg",
+    "draw_plotly_au",
+    "draw_plotly_pose",
+    "emotion_annotation_position",
 ]
 
 
@@ -1383,3 +1389,1039 @@ def load_viz_model(
     except Exception as e:
         raise IOError(f"Unable to load data: {e}")
     return model
+
+
+def face_part_path(row, img_height, line_points):
+    """Helper function to draw SVG path for a specific face part. Requires list of landmark point positions (i.e., [0,1,2]). Last coordinate is end point
+
+    Args:
+        row: (FexSeries) a row of a Fex object
+        img_height (int): the height of the image
+        line_points (list): a list of points on a landmark (i.e., [0:68])
+
+    Returns:
+        fig (str): an SVG string
+    """
+
+    path = ""
+    counter = 0
+    for i in line_points:
+        x = row[f"x_{i}"]
+        y = img_height - row[f"y_{i}"]
+        if counter == 0:
+            path += f"M {x},{y}"
+            counter += 1
+        else:
+            path += f"L {x},{y}"
+    path += " Z"
+    return path
+
+
+def draw_plotly_landmark(
+    row, img_height, fig, line_width=3, line_color="white", output="dictionary"
+):
+    """Helper function to draw an SVG path for a plotly figure object
+
+    Args:
+        row: (FexSeries) a row of a Fex object
+        img_height (int): height of the image to flip the y-coordinates
+        fig: a plotly figure instance
+        output (str): type of output "figure" for plotly figure object or "dictionary"
+        line_width (int): (optional) line width if outputting a plotly figure instance
+        line_color (int): (optional) line color if outputting a plotly figure instance
+
+    Returns:
+        fig (str): an SVG string
+    """
+
+    path = ""
+
+    # Face outline
+    path += face_part_path(
+        row,
+        img_height,
+        [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            15,
+            14,
+            13,
+            12,
+            11,
+            10,
+            9,
+            8,
+            7,
+            6,
+            5,
+            4,
+            3,
+            2,
+            1,
+            0,
+        ],
+    )
+
+    # Left Eye
+    path += face_part_path(row, img_height, [36, 37, 38, 39, 40, 41])
+
+    # Right Eye
+    path += face_part_path(row, img_height, [42, 43, 44, 45, 46, 47])
+
+    # Left Eyebrow
+    path += face_part_path(row, img_height, [17, 18, 19, 20, 21, 20, 19, 18, 17])
+
+    # Right Eyebrow
+    path += face_part_path(row, img_height, [22, 23, 24, 25, 26, 25, 24, 23, 22])
+
+    # Lips1
+    path += face_part_path(
+        row, img_height, [48, 49, 50, 51, 52, 53, 54, 64, 63, 62, 61, 60, 48]
+    )
+
+    # Lips2
+    path += face_part_path(
+        row, img_height, [48, 60, 67, 66, 65, 64, 54, 55, 56, 57, 58, 59, 48]
+    )
+
+    # Nose 1
+    path += face_part_path(row, img_height, [27, 28, 29, 30, 29, 28, 27])
+
+    # Nose 2
+    path += face_part_path(row, img_height, [31, 32, 33, 34, 35, 34, 33, 32, 31])
+
+    if output == "figure":
+        # Draw figure
+        fig.add_shape(
+            type="path", path=path, line_color=line_color, line_width=line_width
+        )
+
+        return fig
+
+    elif output == "dictionary":
+        return dict(
+            type="path", path=path, line=dict(color=line_color, width=line_width)
+        )
+
+    else:
+        raise ValueError('output can only be ["figure","dictionary"]')
+
+
+def face_polygon_svg(line_points, img_height):
+    """Helper function to draw SVG path for a polygon of a specific face part. Requires list of landmark x,y coordinate tuples (i.e., [(2,2),(5,33)]).
+
+    Args:
+        line_points (list): a list of tuples of landmark coordinates
+        img_height (int): height of the image to flip the y-coordinates
+
+    Returns:
+        fig (str): an SVG string
+    """
+
+    path = ""
+    counter = 0
+    for x, y in line_points:
+        y = img_height - y
+        if counter == 0:
+            path += f"M {x},{y}"
+            counter += 1
+        else:
+            path += f"L {x},{y}"
+    path += " Z"
+    return path
+
+
+def draw_plotly_au(
+    row,
+    img_height,
+    fig,
+    heatmap_resolution=1000,
+    au_opacity=0.9,
+    cmap="Blues",
+    output="dictionary",
+):
+    """Helper function to draw an SVG path for a plotly figure object
+
+        NOTES:
+            Need to clean up muscle ids after looking at face anatomy action units
+
+    Args:
+        row (FexSeries): FexSeries instance
+        img_height (int): height of image overlay. used to adjust coordinates
+        fig: plotly figure handle
+        heatmap_resolution (int): precision of cmap
+        au_opacity (float): amount of opacity for face muscles
+        cmap (str): colormap
+        output (str): type of output "figure" for plotly figure object or "dictionary"
+
+    Returns:
+        fig: plotly figure handle
+    """
+
+    muscle_au_dict = {
+        "masseter_l": 15,
+        "masseter_r": 15,
+        "temporalis_l": 15,
+        "temporalis_r": 15,
+        "dep_lab_inf_l": 14,
+        "dep_lab_inf_r": 14,
+        "dep_ang_or_l": 10,
+        "dep_ang_or_r": 10,
+        "mentalis_l": 11,
+        "mentalis_r": 11,
+        "risorius_l": 12,
+        "risorius_r": 12,
+        "frontalis_l": 1,
+        "frontalis_r": 1,
+        "frontalis_inner_l": 0,
+        "frontalis_inner_r": 0,
+        "cor_sup_l": 2,
+        "cor_sup_r": 2,
+        "lev_lab_sup_l": 7,
+        "lev_lab_sup_r": 7,
+        "lev_lab_sup_an_l": 6,
+        "lev_lab_sup_an_r": 6,
+        "zyg_maj_l": 8,
+        "zyg_maj_r": 8,
+        "bucc_l": 9,
+        "bucc_r": 9,
+        "orb_oc_l_outer": 4,
+        "orb_oc_r_outer": 4,
+        "orb_oc_l": 5,
+        "orb_oc_r": 5,
+        "orb_oc_l_inner": 16,
+        "orb_oc_r_inner": 16,
+        "orb_oris_l": 13,
+        "orb_oris_u": 13,
+    }
+
+    #     muscle_au_dict = {"masseter_l": 15,
+    #                         "masseter_r": 15,
+    #                         "temporalis_l": 15,
+    #                         "temporalis_r": 15,
+    #                         "dep_lab_inf_l": 14,
+    #                         "dep_lab_inf_r": 14,
+    #                         "dep_ang_or_l": 10,
+    #                         "dep_ang_or_r": 10,
+    #                         "mentalis_l": 11,
+    #                         "mentalis_r": 11,
+    #                         "risorius_l": 12,
+    #                         "risorius_r": 12,
+    #                         "frontalis_l": 1,
+    #                         "frontalis_r": 1,
+    #                         "frontalis_inner_l": 0,
+    #                         "frontalis_inner_r": 0,
+    #                         "cor_sup_l": 2,
+    #                         "cor_sup_r": 2,
+    #                         "lev_lab_sup_l": 7,
+    #                         "lev_lab_sup_r": 7,
+    #                         "lev_lab_sup_an_l": 6,
+    #                         "lev_lab_sup_an_r": 6,
+    #                         "zyg_maj_l": 8,
+    #                         "zyg_maj_r": 8,
+    #                         "bucc_l": 9,
+    #                         "bucc_r": 9,
+    #                         "orb_oc_l_outer": 4,
+    #                         "orb_oc_r_outer": 4,
+    #                         "orb_oc_l": 5,
+    #                         "orb_oc_r": 5,
+    #                         "orb_oc_l_inner": 16,
+    #                         "orb_oc_r_inner": 16,
+    #                         "orb_oris_l": 13,
+    #                         "orb_oris_u": 13}
+    # #                         "pars_palp_l": 19,
+    # #                         "pars_palp_r": 19,
+    # #                         "masseter_l_rel": 17,
+    # #                         "masseter_r_rel": 17,
+    # #                         "temporalis_l_rel": 17,
+    # #                         "temporalis_r_rel": 17}
+
+    aus = [
+        "AU01",
+        "AU02",
+        "AU04",
+        "AU05",
+        "AU06",
+        "AU07",
+        "AU09",
+        "AU10",
+        "AU11",
+        "AU12",
+        "AU14",
+        "AU15",
+        "AU17",
+        "AU20",
+        "AU23",
+        "AU24",
+        "AU25",
+        "AU26",
+        "AU28",
+        "AU43",
+    ]
+
+    masseter_l = face_polygon_svg(
+        [
+            (row["x_2"], row["y_2"]),
+            (row["x_3"], row["y_3"]),
+            (row["x_4"], row["y_4"]),
+            (row["x_5"], row["y_5"]),
+            (row["x_6"], row["y_6"]),
+            (row["x_5"], row["y_33"]),
+        ],
+        img_height,
+    )
+
+    masseter_r = face_polygon_svg(
+        [
+            (row["x_14"], row["y_14"]),
+            (row["x_13"], row["y_13"]),
+            (row["x_12"], row["y_12"]),
+            (row["x_11"], row["y_11"]),
+            (row["x_10"], row["y_10"]),
+            (row["x_11"], row["y_33"]),
+        ],
+        img_height,
+    )
+
+    temporalis_l = face_polygon_svg(
+        [
+            (row["x_2"], row["y_2"]),
+            (row["x_1"], row["y_1"]),
+            (row["x_0"], row["y_0"]),
+            (row["x_17"], row["y_17"]),
+            (row["x_36"], row["y_36"]),
+        ],
+        img_height,
+    )
+
+    temporalis_r = face_polygon_svg(
+        [
+            (row["x_14"], row["y_14"]),
+            (row["x_15"], row["y_15"]),
+            (row["x_16"], row["y_16"]),
+            (row["x_26"], row["y_26"]),
+            (row["x_45"], row["y_45"]),
+        ],
+        img_height,
+    )
+
+    dep_lab_inf_l = face_polygon_svg(
+        [
+            (row["x_57"], row["y_57"]),
+            (row["x_58"], row["y_58"]),
+            (row["x_59"], row["y_59"]),
+            (row["x_6"], row["y_6"]),
+            (row["x_7"], row["y_7"]),
+        ],
+        img_height,
+    )
+
+    dep_lab_inf_r = face_polygon_svg(
+        [
+            (row["x_57"], row["y_57"]),
+            (row["x_56"], row["y_56"]),
+            (row["x_55"], row["y_55"]),
+            (row["x_10"], row["y_10"]),
+            (row["x_9"], row["y_9"]),
+        ],
+        img_height,
+    )
+
+    dep_ang_or_l = face_polygon_svg(
+        [
+            (row["x_48"], row["y_48"]),
+            (row["x_7"], row["y_7"]),
+            (row["x_6"], row["y_6"]),
+        ],
+        img_height,
+    )
+
+    dep_ang_or_r = face_polygon_svg(
+        [
+            (row["x_54"], row["y_54"]),
+            (row["x_9"], row["y_9"]),
+            (row["x_10"], row["y_10"]),
+        ],
+        img_height,
+    )
+
+    mentalis_l = face_polygon_svg(
+        [
+            (row["x_58"], row["y_58"]),
+            (row["x_7"], row["y_7"]),
+            (row["x_8"], row["y_8"]),
+        ],
+        img_height,
+    )
+
+    mentalis_r = face_polygon_svg(
+        [
+            (row["x_56"], row["y_56"]),
+            (row["x_9"], row["y_9"]),
+            (row["x_8"], row["y_8"]),
+        ],
+        img_height,
+    )
+
+    risorius_l = face_polygon_svg(
+        [
+            (row["x_4"], row["y_4"]),
+            (row["x_5"], row["y_5"]),
+            (row["x_48"], row["y_48"]),
+        ],
+        img_height,
+    )
+
+    risorius_r = face_polygon_svg(
+        [
+            (row["x_11"], row["y_11"]),
+            (row["x_12"], row["y_12"]),
+            (row["x_54"], row["y_54"]),
+        ],
+        img_height,
+    )
+
+    bottom = (row["y_8"] - row["y_57"]) / 2
+
+    orb_oris_l = face_polygon_svg(
+        [
+            (row["x_48"], row["y_48"]),
+            (row["x_59"], row["y_59"]),
+            (row["x_58"], row["y_58"]),
+            (row["x_57"], row["y_57"]),
+            (row["x_56"], row["y_56"]),
+            (row["x_55"], row["y_55"] + bottom),
+            (row["x_54"], row["y_54"] + bottom),
+            (row["x_55"], row["y_55"] + bottom),
+            (row["x_56"], row["y_56"] + bottom),
+            (row["x_57"], row["y_57"] + bottom),
+            (row["x_58"], row["y_58"] + bottom),
+            (row["x_59"], row["y_59"] + bottom),
+        ],
+        img_height,
+    )
+
+    orb_oris_u = face_polygon_svg(
+        [
+            (row["x_48"], row["y_48"]),
+            (row["x_49"], row["y_49"]),
+            (row["x_50"], row["y_50"]),
+            (row["x_51"], row["y_51"]),
+            (row["x_52"], row["y_52"]),
+            (row["x_53"], row["y_53"]),
+            (row["x_54"], row["y_54"]),
+            (row["x_33"], row["y_33"]),
+        ],
+        img_height,
+    )
+
+    frontalis_l = face_polygon_svg(
+        [
+            (row["x_27"], row["y_27"]),
+            (row["x_39"], row["y_39"]),
+            (row["x_38"], row["y_38"]),
+            (row["x_37"], row["y_37"]),
+            (row["x_36"], row["y_36"]),
+            (row["x_17"], row["y_17"]),
+            (row["x_18"], row["y_18"]),
+            (row["x_19"], row["y_19"]),
+            (row["x_20"], row["y_20"]),
+            (row["x_21"], row["y_21"]),
+        ],
+        img_height,
+    )
+
+    frontalis_r = face_polygon_svg(
+        [
+            (row["x_27"], row["y_27"]),
+            (row["x_22"], row["y_22"]),
+            (row["x_23"], row["y_23"]),
+            (row["x_24"], row["y_24"]),
+            (row["x_25"], row["y_25"]),
+            (row["x_26"], row["y_26"]),
+            (row["x_45"], row["y_45"]),
+            (row["x_44"], row["y_44"]),
+            (row["x_43"], row["y_43"]),
+            (row["x_42"], row["y_42"]),
+        ],
+        img_height,
+    )
+
+    frontalis_inner_l = face_polygon_svg(
+        [
+            (row["x_27"], row["y_27"]),
+            (row["x_39"], row["y_39"]),
+            (row["x_21"], row["y_21"]),
+        ],
+        img_height,
+    )
+
+    frontalis_inner_r = face_polygon_svg(
+        [
+            (row["x_27"], row["y_27"]),
+            (row["x_42"], row["y_42"]),
+            (row["x_22"], row["y_22"]),
+        ],
+        img_height,
+    )
+
+    cor_sup_l = face_polygon_svg(
+        [
+            (row["x_28"], row["y_28"]),
+            (row["x_19"], row["y_19"]),
+            (row["x_20"], row["y_20"]),
+        ],
+        img_height,
+    )
+
+    cor_sup_r = face_polygon_svg(
+        [
+            (row["x_28"], row["y_28"]),
+            (row["x_23"], row["y_23"]),
+            (row["x_24"], row["y_24"]),
+        ],
+        img_height,
+    )
+
+    lev_lab_sup_l = face_polygon_svg(
+        [
+            (row["x_41"], row["y_41"]),
+            (row["x_40"], row["y_40"]),
+            (row["x_49"], row["y_49"]),
+        ],
+        img_height,
+    )
+
+    lev_lab_sup_r = face_polygon_svg(
+        [
+            (row["x_47"], row["y_47"]),
+            (row["x_46"], row["y_46"]),
+            (row["x_53"], row["y_53"]),
+        ],
+        img_height,
+    )
+
+    lev_lab_sup_an_l = face_polygon_svg(
+        [
+            (row["x_39"], row["y_39"]),
+            (row["x_49"], row["y_49"]),
+            (row["x_31"], row["y_31"]),
+        ],
+        img_height,
+    )
+
+    lev_lab_sup_an_r = face_polygon_svg(
+        [
+            (row["x_35"], row["y_35"]),
+            (row["x_42"], row["y_42"]),
+            (row["x_53"], row["y_53"]),
+        ],
+        img_height,
+    )
+
+    zyg_maj_l = face_polygon_svg(
+        [
+            (row["x_48"], row["y_48"]),
+            (row["x_3"], row["y_3"]),
+            (row["x_2"], row["y_2"]),
+        ],
+        img_height,
+    )
+
+    zyg_maj_r = face_polygon_svg(
+        [
+            (row["x_54"], row["y_54"]),
+            (row["x_13"], row["y_13"]),
+            (row["x_14"], row["y_14"]),
+        ],
+        img_height,
+    )
+
+    bucc_l = face_polygon_svg(
+        [
+            (row["x_48"], row["y_48"]),
+            (row["x_5"], row["y_50"]),
+            (row["x_5"], row["y_57"]),
+        ],
+        img_height,
+    )
+
+    bucc_r = face_polygon_svg(
+        [
+            (row["x_54"], row["y_54"]),
+            (row["x_11"], row["y_52"]),
+            (row["x_11"], row["y_57"]),
+        ],
+        img_height,
+    )
+
+    width_l = (row["y_21"] - row["y_39"]) / 2
+
+    orb_oc_l = face_polygon_svg(
+        [
+            (row["x_36"] - width_l / 3, row["y_36"] + width_l / 2),
+            (row["x_36"], row["y_36"] + width_l),
+            (row["x_37"], row["y_37"] + width_l),
+            (row["x_38"], row["y_38"] + width_l),
+            (row["x_39"], row["y_39"] + width_l),
+            (row["x_39"] + width_l / 3, row["y_39"] + width_l / 2),
+            (row["x_39"] + width_l / 2, row["y_39"]),
+            (row["x_39"] + width_l / 3, row["y_39"] - width_l / 2),
+            (row["x_39"], row["y_39"] - width_l),
+            (row["x_40"], row["y_40"] - width_l),
+            (row["x_41"], row["y_41"] - width_l),
+            (row["x_36"], row["y_36"] - width_l),
+            (row["x_36"] - width_l / 3, row["y_36"] - width_l / 2),
+            (row["x_36"] - width_l / 2, row["y_36"]),
+        ],
+        img_height,
+    )
+
+    orb_oc_l_inner = face_polygon_svg(
+        [
+            (row["x_36"] - width_l / 6, row["y_36"] + width_l / 5),
+            (row["x_36"], row["y_36"] + width_l / 2),
+            (row["x_37"], row["y_37"] + width_l / 2),
+            (row["x_38"], row["y_38"] + width_l / 2),
+            (row["x_39"], row["y_39"] + width_l / 2),
+            (row["x_39"] + width_l / 6, row["y_39"] + width_l / 5),
+            (row["x_39"] + width_l / 5, row["y_39"]),
+            (row["x_39"] + width_l / 6, row["y_39"] - width_l / 5),
+            (row["x_39"], row["y_39"] - width_l),
+            (row["x_40"], row["y_40"] - width_l),
+            (row["x_41"], row["y_41"] - width_l),
+            (row["x_36"], row["y_36"] - width_l),
+            (row["x_36"] - width_l / 6, row["y_36"] - width_l / 5),
+            (row["x_36"] - width_l / 5, row["y_36"]),
+        ],
+        img_height,
+    )
+
+    width_l2 = (row["y_38"] - row["y_2"]) / 1.5
+
+    orb_oc_l_outer = face_polygon_svg(
+        [
+            (row["x_39"] + width_l / 2, row["y_39"] + width_l / 2),
+            (row["x_39"], row["y_39"] - width_l),
+            (row["x_40"], row["y_40"] - width_l2),
+            (row["x_41"], row["y_41"] - width_l2),
+            (row["x_36"], row["y_36"] - width_l2),
+            (row["x_36"] - width_l2 / 3, row["y_36"] - width_l2 / 2),
+            (row["x_36"] - width_l / 2, row["y_36"]),
+        ],
+        img_height,
+    )
+
+    width_r = (row["y_23"] - row["y_43"]) / 2
+
+    orb_oc_r = face_polygon_svg(
+        [
+            (row["x_42"] - width_r / 3, row["y_42"] + width_r / 2),
+            (row["x_42"], row["y_42"] + width_r),
+            (row["x_43"], row["y_43"] + width_r),
+            (row["x_44"], row["y_44"] + width_r),
+            (row["x_45"], row["y_45"] + width_r),
+            (row["x_45"] + width_r / 3, row["y_45"] + width_r / 2),
+            (row["x_45"] + width_r / 2, row["y_45"]),
+            (row["x_45"] + width_r / 3, row["y_45"] - width_r / 2),
+            (row["x_45"], row["y_45"] - width_r),
+            (row["x_46"], row["y_46"] - width_r),
+            (row["x_47"], row["y_47"] - width_r),
+            (row["x_42"], row["y_42"] - width_r),
+            (row["x_42"] - width_l / 3, row["y_42"] - width_r / 2),
+            (row["x_42"] - width_r / 2, row["y_42"]),
+        ],
+        img_height,
+    )
+
+    orb_oc_r_inner = face_polygon_svg(
+        [
+            (row["x_42"] - width_r / 6, row["y_42"] + width_r / 5),
+            (row["x_42"], row["y_42"] + width_r / 2),
+            (row["x_43"], row["y_43"] + width_r / 2),
+            (row["x_44"], row["y_44"] + width_r / 2),
+            (row["x_45"], row["y_45"] + width_r / 2),
+            (row["x_45"] + width_r / 6, row["y_45"] + width_r / 5),
+            (row["x_45"] + width_r / 5, row["y_45"]),
+            (row["x_45"] + width_r / 6, row["y_45"] - width_r / 5),
+            (row["x_45"], row["y_45"] - width_r / 2),
+            (row["x_46"], row["y_46"] - width_r / 2),
+            (row["x_47"], row["y_47"] - width_r / 2),
+            (row["x_42"], row["y_42"] - width_r / 2),
+            (row["x_42"] - width_l / 6, row["y_42"] - width_r / 5),
+            (row["x_42"] - width_r / 5, row["y_42"]),
+        ],
+        img_height,
+    )
+
+    width_r2 = (row["y_44"] - row["y_14"]) / 1.5
+
+    orb_oc_r_outer = face_polygon_svg(
+        [
+            (row["x_42"] - width_r / 2, row["y_42"]),
+            (row["x_47"], row["y_47"] - width_r2),
+            (row["x_46"], row["y_46"] - width_r2),
+            (row["x_45"], row["y_45"] - width_r2),
+            (row["x_45"] + width_r2 / 3, row["y_45"] - width_r2 / 2),
+            (row["x_45"] + width_r / 2, row["y_45"]),
+        ],
+        img_height,
+    )
+
+    eye_l = face_polygon_svg(
+        [
+            (row["x_36"], row["y_36"]),
+            (row["x_37"], row["y_37"]),
+            (row["x_38"], row["y_38"]),
+            (row["x_39"], row["y_39"]),
+            (row["x_40"], row["y_40"]),
+            (row["x_41"], row["y_41"]),
+        ],
+        img_height,
+    )
+
+    eye_r = face_polygon_svg(
+        [
+            (row["x_42"], row["y_42"]),
+            (row["x_43"], row["y_43"]),
+            (row["x_44"], row["y_44"]),
+            (row["x_45"], row["y_45"]),
+            (row["x_46"], row["y_46"]),
+            (row["x_47"], row["y_47"]),
+        ],
+        img_height,
+    )
+
+    # Outside Mouth
+    #     mouth = face_polygon_path([(row['x_48'],row['y_48']),
+    #                                (row['x_49'],row['y_49']),
+    #                                (row['x_50'],row['y_50']),
+    #                                (row['x_51'],row['y_51']),
+    #                                (row['x_52'],row['y_52']),
+    #                                (row['x_53'],row['y_53']),
+    #                                (row['x_54'],row['y_54']),
+    #                                (row['x_55'],row['y_55']),
+    #                                (row['x_56'],row['y_56']),
+    #                                (row['x_57'],row['y_57']),
+    #                                (row['x_58'],row['y_58']),
+    #                                (row['x_59'],row['y_59'])], img_height)
+    # Inside Mouth
+    mouth = face_polygon_svg(
+        [
+            (row["x_60"], row["y_60"]),
+            (row["x_61"], row["y_61"]),
+            (row["x_62"], row["y_62"]),
+            (row["x_63"], row["y_63"]),
+            (row["x_64"], row["y_64"]),
+            (row["x_65"], row["y_65"]),
+            (row["x_66"], row["y_66"]),
+            (row["x_67"], row["y_67"]),
+        ],
+        img_height,
+    )
+
+    pupil_l = [
+        (
+            (
+                row["x_36"]
+                + row["x_37"]
+                + row["x_38"]
+                + row["x_40"]
+                + row["x_41"]
+                + row["x_39"]
+            )
+            / 6,
+            (
+                img_height
+                - (
+                    row["y_36"]
+                    + row["y_37"]
+                    + row["y_38"]
+                    + row["y_40"]
+                    + row["y_41"]
+                    + row["y_39"]
+                )
+                / 6
+            ),
+        ),
+        (
+            (row["x_38"] + row["x_40"]) / 2,
+            (img_height - (row["y_37"] + row["y_38"]) / 2),
+        ),
+    ]
+    pupil_r = [
+        (
+            (row["x_43"] + row["x_44"] + row["x_46"] + row["x_47"]) / 4,
+            (img_height - (row["y_43"] + row["y_44"] + row["y_46"] + row["y_47"]) / 4),
+        ),
+        (
+            (row["x_44"] + row["x_46"]) / 2,
+            (img_height - (row["y_43"] + row["y_44"]) / 2),
+        ),
+    ]
+
+    # Build AU heatmap
+    cmap = sns.color_palette(cmap, heatmap_resolution + 1)
+
+    if output == "figure":
+        for muscle in list(muscle_au_dict.keys()):
+            color = cmap.as_hex()[
+                int(row[aus[muscle_au_dict[muscle]]] * heatmap_resolution)
+            ]
+            fig.add_shape(
+                type="path",
+                path=eval(muscle),
+                line_color=color,
+                fillcolor=color,
+                opacity=au_opacity,
+            )
+
+            for region in [eye_l, eye_r, mouth]:
+                fig.add_shape(
+                    type="path",
+                    path=region,
+                    line_color="black",
+                    line_width=2,
+                    fillcolor="white",
+                )
+
+            for pupil in [pupil_l, pupil_r]:
+                fig.add_shape(
+                    type="circle",
+                    xref="x",
+                    yref="y",
+                    fillcolor="black",
+                    x0=pupil[0][0],
+                    y0=pupil[0][1],
+                    x1=pupil[1][0],
+                    y1=pupil[1][1],
+                    line_color="black",
+                    line_width=3,
+                )
+
+        return fig
+
+    elif output == "dictionary":
+        muscles = []
+        for muscle in list(muscle_au_dict.keys()):
+            color = cmap.as_hex()[
+                int(row[aus[muscle_au_dict[muscle]]] * heatmap_resolution)
+            ]
+            muscles.append(
+                dict(
+                    type="path",
+                    path=eval(muscle),
+                    fillcolor=color,
+                    opacity=au_opacity,
+                    line=dict(color=color),
+                )
+            )
+
+        regions = []
+        for region in [eye_l, eye_r, mouth]:
+            regions.append(
+                dict(
+                    type="path",
+                    path=region,
+                    line_width=2,
+                    fillcolor="white",
+                    line=dict(color="black"),
+                )
+            )
+
+        pupils = []
+        for pupil in [pupil_l, pupil_r]:
+            pupils.append(
+                dict(
+                    type="circle",
+                    xref="x",
+                    yref="y",
+                    fillcolor="black",
+                    x0=pupil[0][0],
+                    y0=pupil[0][1],
+                    x1=pupil[1][0],
+                    y1=pupil[1][1],
+                    line_width=3,
+                    line=dict(color="black"),
+                )
+            )
+        return flatten_list([muscles, regions, pupils])
+
+    else:
+        raise ValueError('output can only be ["figure","dictionary"]')
+
+
+def draw_plotly_pose(row, img_height, fig, line_width=2, output="dictionary"):
+    """
+    Helper function to draw a path indicating the x,y,z pose position.
+
+    Args:
+        row (FexSeries): FexSeries instance
+        img_height (int): height of image overlay. used to adjust coordinates
+        fig: plotly figure handle
+        line_width (int): (optional) width of line if outputing a plotly figure instance
+        output (str): type of output "figure" for plotly figure object or "dictionary"
+
+    Returns:
+        fig: plotly figure handle
+    """
+
+    # Center axis on facebox
+    x1, y1, w, h = row[["FaceRectX", "FaceRectY", "FaceRectWidth", "FaceRectHeight"]]
+    x2, y2 = x1 + w, y1 + h
+    tdx = (x1 + x2) / 2
+    tdy = (y1 + y2) / 2
+
+    # Make rotation axis lines proportional to facebox size
+    size = min(x2 - x1, y2 - y1) // 2
+
+    # Get pose axes
+    pitch, roll, yaw = row[["Pitch", "Roll", "Yaw"]]
+    pitch = pitch * np.pi / 180
+    yaw = -(yaw * np.pi / 180)
+    roll = roll * np.pi / 180
+
+    # X-Axis pointing to right. drawn in red
+    x1 = size * (np.cos(yaw) * np.cos(roll)) + tdx
+    y1 = (
+        size
+        * (np.cos(pitch) * np.sin(roll) + np.cos(roll) * np.sin(pitch) * np.sin(yaw))
+        + tdy
+    )
+
+    # Y-Axis | drawn in green
+    x2 = size * (-np.cos(yaw) * np.sin(roll)) + tdx
+    y2 = (
+        size
+        * (np.cos(pitch) * np.cos(roll) - np.sin(pitch) * np.sin(yaw) * np.sin(roll))
+        + tdy
+    )
+
+    # Z-Axis (out of the screen) drawn in blue
+    x3 = size * (np.sin(yaw)) + tdx
+    y3 = size * (-np.cos(yaw) * np.sin(pitch)) + tdy
+
+    # Flip y coordinates
+    tdy, y1, y2, y3 = [img_height - c for c in [tdy, y1, y2, y3]]
+
+    if output == "figure":
+        # Draw face and pose axes
+        fig.add_shape(
+            type="line",
+            x0=tdx,
+            y0=tdy,
+            x1=x1,
+            y1=y1,
+            line=dict(color="red", width=line_width),
+        )
+        fig.add_shape(
+            type="line",
+            x0=tdx,
+            y0=tdy,
+            x1=x2,
+            y1=y2,
+            line=dict(color="green", width=line_width),
+        )
+        fig.add_shape(
+            type="line",
+            x0=tdx,
+            y0=tdy,
+            x1=x3,
+            y1=y3,
+            line=dict(color="blue", width=line_width),
+        )
+        return fig
+
+    elif output == "dictionary":
+        return [
+            dict(type="line", x0=tdx, y0=tdy, x1=x1, y1=y1, line=dict(color="red")),
+            dict(type="line", x0=tdx, y0=tdy, x1=x2, y1=y2, line=dict(color="green")),
+            dict(type="line", x0=tdx, y0=tdy, x1=x3, y1=y3, line=dict(color="blue")),
+        ]
+    #     return [dict(type='line', x0=tdx, y0=tdy, x1=x1, y1=y1, line_color="red", width=line_width),
+    #                 dict(type='line', x0=tdx, y0=tdy, x1=x2, y1=y2, line_color="green", width=line_width),
+    #                 dict(type='line', x0=tdx, y0=tdy, x1=x3, y1=y3, line_color="blue", width=line_width)]
+
+    else:
+        raise ValueError('output can only be ["figure","dictionary"]')
+
+
+def emotion_annotation_position(
+    row, img_height, img_width, emotions_size=12, emotions_position="bottom"
+):
+    """Helper function to adjust position of emotion annotations
+
+    Args:
+        row (FexSeries): FexSeries instance
+        img_height (int): height of image overlay. used to adjust coordinates
+        img_width (int): width of image overlay. used to adjust coordinates
+        emotions_size (int): size of text used to adjust positions
+        emotions_position (str): position to place emotion annotations ['left', 'right', 'top', 'bottom']
+
+    Returns:
+        x_position (int):
+        y_position (int):
+        align (str): plotly annotation text alignment ['top','bottom', 'left', 'right ]
+        valign (str): plotly annotation vertical alignment ['middle', 'top', 'bottom']
+    """
+
+    y_spacing = img_height * 0.01 * emotions_size * 0.5
+    x_spacing = img_width * 0.02 * emotions_size * 0.18
+
+    if emotions_position.lower() == "bottom":
+        x_position = row["FaceRectX"] + row["FaceRectWidth"] / 2
+        y_position = (
+            img_height
+            - row["FaceRectY"]
+            - row["FaceRectHeight"]
+            - img_height * 0.04
+            - y_spacing
+        )
+        align = "left"
+        valign = "bottom"
+    elif emotions_position.lower() == "top":
+        x_position = row["FaceRectX"] + row["FaceRectWidth"] / 2
+        y_position = (
+            img_height
+            - row["FaceRectY"]
+            + row["FaceRectHeight"] / 2
+            + y_spacing
+            - img_height * 0.04
+        )
+        align = "left"
+        valign = "bottom"
+    elif emotions_position.lower() == "right":
+        x_position = (
+            row["FaceRectX"] + row["FaceRectWidth"] + img_width * 0.025 + x_spacing
+        )
+        y_position = img_height - row["FaceRectY"] - row["FaceRectHeight"] / 2
+        align = "left"
+        valign = "middle"
+    elif emotions_position.lower() == "left":
+        x_position = (
+            row["FaceRectX"] - row["FaceRectWidth"] / 2 - x_spacing + img_width * 0.01
+        )
+        y_position = img_height - row["FaceRectY"] - row["FaceRectHeight"] / 2
+        align = "right"
+        valign = "middle"
+    else:
+        raise ValueError(
+            '"emotions_position" must be one of ["bottom","top","left","right"]'
+        )
+
+    return (x_position, y_position, align, valign)

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -2219,13 +2219,12 @@ def draw_plotly_au(
     elif output == "dictionary":
         muscles = []
         for muscle in list(muscle_au_dict.keys()):
-            
-            if isinstance(row[aus[muscle_au_dict[muscle]]],(np.nan)):
+            if isinstance(row[aus[muscle_au_dict[muscle]]], (np.nan)):
                 au_intensity = 0
             else:
-                au_intensity = int(row[aus[muscle_au_dict[muscle]]]                
+                au_intensity = int(row[aus[muscle_au_dict[muscle]]])
             color = cmap.as_hex()[au_intensity * heatmap_resolution]
-            
+
             muscles.append(
                 dict(
                     type="path",

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -24,7 +24,6 @@ from feat.utils import flatten_list
 from feat.utils.io import get_resource_path, download_url
 from feat.utils.image_operations import convert_image_to_tensor
 from feat.pretrained import AU_LANDMARK_MAP
-from feat.detector import Detector
 import json
 import av
 import torch
@@ -2698,6 +2697,7 @@ def pyfeat_live_demo(
         av_options (dict): dictionary of optional arguments for pyav {'video_size': '1280x720','framerate': '30'}
 
     """
+    from feat.detector import Detector
 
     global capture_start_flag, capture_stop_flag, record_video, image_visible, facebox_visible, landmark_visible, pose_visible, au_visible, emotion_visible, active_button_color, inactive_button_color
     capture_start_flag = False

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -2219,9 +2219,13 @@ def draw_plotly_au(
     elif output == "dictionary":
         muscles = []
         for muscle in list(muscle_au_dict.keys()):
-            color = cmap.as_hex()[
-                int(row[aus[muscle_au_dict[muscle]]] * heatmap_resolution)
-            ]
+            
+            if isinstance(row[aus[muscle_au_dict[muscle]]],(np.nan)):
+                au_intensity = 0
+            else:
+                au_intensity = int(row[aus[muscle_au_dict[muscle]]]                
+            color = cmap.as_hex()[au_intensity * heatmap_resolution]
+            
             muscles.append(
                 dict(
                     type="path",

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -2180,9 +2180,11 @@ def draw_plotly_au(
 
     if output == "figure":
         for muscle in list(muscle_au_dict.keys()):
-            color = cmap.as_hex()[
-                int(row[aus[muscle_au_dict[muscle]]] * heatmap_resolution)
-            ]
+            if np.isnan(row[aus[muscle_au_dict[muscle]]]):
+                au_intensity = 0
+            else:
+                au_intensity = int(row[aus[muscle_au_dict[muscle]]])
+            color = cmap.as_hex()[au_intensity * heatmap_resolution]
             fig.add_shape(
                 type="path",
                 path=eval(muscle),
@@ -2219,7 +2221,7 @@ def draw_plotly_au(
     elif output == "dictionary":
         muscles = []
         for muscle in list(muscle_au_dict.keys()):
-            if isinstance(row[aus[muscle_au_dict[muscle]]], (np.nan)):
+            if np.isnan(row[aus[muscle_au_dict[muscle]]]):
                 au_intensity = 0
             else:
                 au_intensity = int(row[aus[muscle_au_dict[muscle]]])

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -29,7 +29,8 @@ import av
 import torch
 import asyncio
 from ipywidgets import Button, VBox, HBox, Output
-from IPython.display import display
+
+# from IPython.display import display
 import plotly.graph_objects as go
 from tqdm.notebook import tqdm
 
@@ -2189,11 +2190,14 @@ def draw_plotly_au(
 
     if output == "figure":
         for muscle in list(muscle_au_dict.keys()):
-            if np.isnan(row[aus[muscle_au_dict[muscle]]]):
+            if np.isnan(row[aus[muscle_au_dict[muscle]]][0]):
                 au_intensity = 0
             else:
-                au_intensity = int(row[aus[muscle_au_dict[muscle]]])
-            color = cmap.as_hex()[au_intensity * heatmap_resolution]
+                au_intensity = int(
+                    row[aus[muscle_au_dict[muscle]]][0] * heatmap_resolution
+                )
+
+            color = cmap.as_hex()[au_intensity]
             fig.add_shape(
                 type="path",
                 path=eval(muscle),
@@ -2233,8 +2237,10 @@ def draw_plotly_au(
             if np.isnan(row[aus[muscle_au_dict[muscle]]]):
                 au_intensity = 0
             else:
-                au_intensity = int(row[aus[muscle_au_dict[muscle]]])
-            color = cmap.as_hex()[au_intensity * heatmap_resolution]
+                au_intensity = int(
+                    row[aus[muscle_au_dict[muscle]]] * heatmap_resolution
+                )
+            color = cmap.as_hex()[au_intensity]
 
             muscles.append(
                 dict(
@@ -2819,7 +2825,9 @@ def pyfeat_live_demo(
     ):
         """Asyncronous function to capture video from webcam and process it with py-feat"""
 
-        def update_figure_elements():
+        def update_figure_elements(
+            fig, image_frame, faceboxes_path, landmarks_path, poses_path, aus_path
+        ):
             """Update all figure elements depending on what is toggled"""
 
             global image_visible, facebox_visible, landmark_visible, pose_visible, au_visible, emotion_visible
@@ -2885,6 +2893,7 @@ def pyfeat_live_demo(
                 sizing="stretch",
                 source=frame.to_image(),
             )
+
             if frame_counter == 0:
                 # Create figure
                 figure = go.Figure()
@@ -2952,12 +2961,15 @@ def pyfeat_live_demo(
                 au_cmap=au_cmap,
             )
 
-            update_figure_elements()
-            frame_counter += 1
+            update_figure_elements(
+                fig, image_frame, faceboxes_path, landmarks_path, poses_path, aus_path
+            )
 
             if record_video:
                 loop = asyncio.get_event_loop()
                 loop.create_task(record_fex_to_file(save_fex_file, frame_fex, fig))
+
+            frame_counter += 1
 
             # Stop if hit max frames
             if frame_counter > max_frames:

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -31,6 +31,7 @@ import asyncio
 from ipywidgets import Button, VBox, HBox, Output
 from IPython.display import display
 import plotly.graph_objects as go
+from tqdm.notebook import tqdm
 
 __all__ = [
     "draw_lineface",
@@ -2497,7 +2498,12 @@ async def run_pyfeat_detection_async(
     """
     loop = asyncio.get_event_loop()
     result = await loop.run_in_executor(
-        None, run_pyfeat_detection, frame_img, frame_counter, face_detection_threshold
+        None,
+        run_pyfeat_detection,
+        detector,
+        frame_img,
+        frame_counter,
+        face_detection_threshold,
     )
     return result
 

--- a/feat/utils/__init__.py
+++ b/feat/utils/__init__.py
@@ -158,3 +158,11 @@ def set_torch_device(device="cpu"):
 def is_list_of_lists_empty(list_of_lists):
     """Helper function to check if list of lists is empty"""
     return not any(list_of_lists)
+
+
+def flatten_list(data):
+    """Helper function to flatten a list of lists"""
+    flat_list = []
+    for row in data:
+        flat_list += row
+    return flat_list

--- a/feat/utils/io.py
+++ b/feat/utils/io.py
@@ -2,6 +2,7 @@
 Feat utility and helper functions for inputting and outputting data.
 """
 
+import warnings
 import os
 import contextlib
 import pandas as pd

--- a/feat/utils/io.py
+++ b/feat/utils/io.py
@@ -18,8 +18,9 @@ from feat.utils import (
     openface_time_columns,
 )
 
-
 from torchvision.datasets.utils import download_url as tv_download_url
+from torchvision.io import read_image, read_video
+from torchvision.transforms.functional import to_pil_image
 
 __all__ = [
     "get_resource_path",
@@ -27,6 +28,7 @@ __all__ = [
     "validate_input",
     "download_url",
     "read_openface",
+    "load_pil_img",
 ]
 
 
@@ -199,3 +201,28 @@ def read_openface(openfacefile, features=None):
     )
     fex["input"] = openfacefile
     return fex
+
+
+def load_pil_img(file_name, frame_id):
+    """Helper function to load a PIL image from a picture or video
+
+    Args:
+        file_name (str): path to file. Can be image or video
+        frame_id (int): if video, load frame
+
+    Returns:
+        image: pil image instance
+    """
+
+    file_extension = os.path.basename(file_name).split(".")[-1]
+    if file_extension.lower() in ["jpg", "jpeg", "png", "bmp", "tiff", "pdf"]:
+        frame_img = read_image(file_name)  # image path
+    else:
+        # Ignore UserWarning: The pts_unit 'pts' gives wrong results. Please use
+        # pts_unit 'sec'. See why it's ok in this issue:
+        # https://github.com/pytorch/vision/issues/1931
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            video, audio, info = read_video(file_name, output_format="TCHW")
+        frame_img = video[frame_id, :, :]
+    return to_pil_image(frame_img)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,7 @@ tqdm
 kornia
 av>=9.2.0
 xgboost>=1.6.0
-plotly>=5.6.0
+plotly>=5.9.0
 kaleido
+ipywidgets==7.8.0
+jupyterlab-widgets==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ tqdm
 kornia
 av>=9.2.0
 xgboost>=1.6.0
+plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ tqdm
 kornia
 av>=9.2.0
 xgboost>=1.6.0
-plotly
+plotly>=5.6.0
+kaleido


### PR DESCRIPTION
In this PR, i have rewritten the `plot_detections()` method of Fex objects to use plotly backend instead of matplotlib. There 
are now two new ways to create interactive visualizations of detectors using plotly.  Initial discussion in issue #177 and addresses enhancement in #46. 

`plot_singleframe_detections()` - plots a single image frame from image or video and allows users to interactively toggle individual detectors. Unfortunately, users can currently only toggle a single detector, I have not yet been able to figure out how to elegantly allow the indepedent toggling of detectors without creating separate buttons to toggle each on and off.

![image](https://github.com/cosanlab/py-feat/assets/2993338/13a2d532-59a8-4218-a574-c7387545e738)

`plot_multipleframes_detections()` - plots a series of image frames as a plotly animation and allows users to interactively slide through detection results for individual frames. The specific type of detector to plot must be prespecified as a boolean when calling the function.

![image](https://github.com/cosanlab/py-feat/assets/2993338/39672176-f7a9-4832-9615-8283cf27a451)

Ideally, we would be able to combine these two different types of plots into a single plot, but I have not yet been able to get it to reliably work yet.  While plotly offers a lot of flexibility, the two different types of interactivity create lots of conflicts with each other. For now, the updated `plot_detections()` method automatically detects which type of plot to use.

Here are the tasks to complete:

- [x] add facebox visualization 
- [x] add landmark visualization 
- [x] add pose visualization 
- [x] add au visualization 
- [x] add emotion visualization 
- [x] add positions for emotion annotations
- [x] add slider to scroll through frames
- [x] add buttons to toggle landmarks, faceboxes, au maps
- [x] turn into `plot_detections()` method
- [ ] streamline muscle au dictionary
- [ ] add examples for saving plots and videos
- [ ] add tooltips to visualize detector output for each face
- [ ] allow multiple detectors to be toggled in `plot_singleframe_detections()`
- [ ] add adjustment buttons for playback speed in `plot_multipleframes_detections`
- [ ] ideally, both types of interactivity would be combined into a single plot
- [ ] add tests for figures. I'm still not sure what the best way to do this is. 
- [ ] add new function to plot faces from AUs (the other main way to generate plots in py-feat)
- [x] add new function to create live plots

I still need to streamline the AU dictionaries and confirm the drawing locations are accurate that @skbyrne started. Will need one of my AU anatomy books for this.

I will need some help testing this to make sure everything is working reliably and also fixing some of the idiosyncratic spacing issues. I also still need to write tests, but am not sure what the best practices are for writing plot tests in python.

@ejolly, when you have some time it would be great to get your feedback on this.
