### PR TITLE
add option to download default models

### DIFF
--- a/feat/pretrained.py
+++ b/feat/pretrained.py
@@ -115,6 +115,7 @@ def get_pretrained_models(
         )
     )
 
+    print("Downloading required models...")
     # Face model
     if face_model is None:
         raise ValueError(
@@ -257,3 +258,16 @@ def fetch_model(model_type, model_name):
     model_type = PRETRAINED_MODELS[model_type]
     matches = list(filter(lambda e: model_name in e.keys(), model_type))[0]
     return list(matches.values())[0]
+
+
+def download_default_models():
+    """Used by CLI to download all default models at once."""
+    face, landmark, au, emotion, facepose, identity = get_pretrained_models(
+        face_model="retinaface",
+        landmark_model="mobilefacenet",
+        au_model="xgb",
+        emotion_model="resmasknet",
+        facepose_model="img2pose",
+        identity_model="facenet",
+        verbose=False,
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-from feat.pretrained import get_pretrained_models
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
@@ -9,18 +8,6 @@ with open("feat/version.py") as f:
     exec(f.read(), version)
 
 extra_setuptools_args = dict(tests_require=["pytest"])
-
-
-def download_default_models():
-    face, landmark, au, emotion, facepose, identity = get_pretrained_models(
-        face_model="retinaface",
-        landmark_model="mobilefacenet",
-        au_model="xgb",
-        emotion_model="resmasknet",
-        facepose_model="img2pose",
-        identity_model="facenet",
-    )
-
 
 setup(
     name="py-feat",
@@ -44,10 +31,10 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    extras_require={
-        "default_models": [
-            download_default_models,
-        ],
+    entry_points={
+        "console_scripts": [
+            "feat_get_models=feat.pretrained:download_default_models",
+        ]
     },
     test_suite="feat/tests",
     **extra_setuptools_args

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from feat.pretrained import get_pretrained_models
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
@@ -8,6 +9,18 @@ with open("feat/version.py") as f:
     exec(f.read(), version)
 
 extra_setuptools_args = dict(tests_require=["pytest"])
+
+
+def download_default_models():
+    face, landmark, au, emotion, facepose, identity = get_pretrained_models(
+        face_model="retinaface",
+        landmark_model="mobilefacenet",
+        au_model="xgb",
+        emotion_model="resmasknet",
+        facepose_model="img2pose",
+        identity_model="facenet",
+    )
+
 
 setup(
     name="py-feat",
@@ -31,6 +44,11 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    extras_require={
+        "default_models": [
+            download_default_models,
+        ],
+    },
     test_suite="feat/tests",
     **extra_setuptools_args
 )


### PR DESCRIPTION
This PR adds an option when installing py-feat via pip to also download the default models.

`pip install py-feat[default_models]`

@ejolly Let's make sure this works first before merging as I havent really tested it yet.