### PR TITLE
Updated Fex I/O

### DIFF
--- a/feat/__init__.py
+++ b/feat/__init__.py
@@ -10,4 +10,5 @@ __all__ = ["detector", "data", "utils", "plotting", "transforms", "__version__"]
 
 from .data import Fex
 from .detector import Detector
+from .utils.io import read_fex
 from .version import __version__

--- a/feat/data.py
+++ b/feat/data.py
@@ -2316,4 +2316,3 @@ class VideoDataset(Dataset):
         minutes = int(duration // 60)
         seconds = int(duration % 60)
         return f"{minutes:02d}:{seconds:02d}"
-s

--- a/feat/data.py
+++ b/feat/data.py
@@ -1912,25 +1912,30 @@ class Fex(DataFrame):
             )
 
         return out
-    
+
     def write(self, file_name):
-        '''Write out Fex file to CSV with metadata as JSON in first line
-        
+        """Write out Fex file to CSV with metadata as JSON in first line
+
         Args:
             file_name: (str) name of file to write out
-        '''
-        
+        """
+
         meta_dict = {}
         for name in self._metadata:
             meta_dict[name] = getattr(self, name, None)
-        
-        del meta_dict['fex_columns'] # we should probably remove this attribute in the future.
-        
+
+        del meta_dict[
+            "fex_columns"
+        ]  # we should probably remove this attribute in the future.
+
         meta_json = json.dumps(meta_dict)
-        
-        with open(file_name, 'w') as f:
-            f.write(f'# {meta_json}\n')  # Write metadata as a comment at the top of the file
+
+        with open(file_name, "w") as f:
+            f.write(
+                f"# {meta_json}\n"
+            )  # Write metadata as a comment at the top of the file
             self.to_csv(f, index=False)
+
 
 class ImageDataset(Dataset):
     """Torch Image Dataset

--- a/feat/tests/test_data.py
+++ b/feat/tests/test_data.py
@@ -260,11 +260,12 @@ def test_feat():
     # test input property
     assert fex.input.values[0] == fex.iloc[0].input
 
+
 def test_feat_io(default_detector, single_face_img):
     fex1 = default_detector.detect_image(single_face_img)
-    fex1.write('Feat_Test_With_Metadata.csv')
-    
-    fex2 = read_fex('Feat_Test_With_Metadata.csv')
+    fex1.write("Feat_Test_With_Metadata.csv")
+
+    fex2 = read_fex("Feat_Test_With_Metadata.csv")
     assert fex1.face_model == fex2.face_model
     assert fex1.landmark_model == fex2.landmark_model
     assert fex1.facepose_model == fex2.facepose_model
@@ -276,9 +277,9 @@ def test_feat_io(default_detector, single_face_img):
     assert len(fex1.au_columns) == len(fex2.au_columns)
     assert len(fex1.landmark_columns) == len(fex2.landmark_columns)
     assert len(fex1.identity_columns) == len(fex2.identity_columns)
-    assert fex1.aus['AU01'].values[0] == fex2.aus['AU01'].values[0]
-    
-    
+    assert fex1.aus["AU01"].values[0] == fex2.aus["AU01"].values[0]
+
+
 def test_stats():
     filename = os.path.join(get_test_data_path(), "OpenFace_Test.csv")
     openface = Fex(filename=filename, sampling_freq=30, detector="OpenFace")

--- a/feat/tests/test_data.py
+++ b/feat/tests/test_data.py
@@ -4,7 +4,7 @@ from pandas import DataFrame
 import numpy as np
 import os
 from feat.data import Fex
-from feat.utils.io import read_openface, get_test_data_path, read_feat
+from feat.utils.io import read_openface, get_test_data_path, read_feat, read_fex
 from nltools.data import Adjacency
 
 
@@ -260,7 +260,25 @@ def test_feat():
     # test input property
     assert fex.input.values[0] == fex.iloc[0].input
 
-
+def test_feat_io(default_detector, single_face_img):
+    fex1 = default_detector.detect_image(single_face_img)
+    fex1.write('Feat_Test_With_Metadata.csv')
+    
+    fex2 = read_fex('Feat_Test_With_Metadata.csv')
+    assert fex1.face_model == fex2.face_model
+    assert fex1.landmark_model == fex2.landmark_model
+    assert fex1.facepose_model == fex2.facepose_model
+    assert fex1.au_model == fex2.au_model
+    assert fex1.identity_model == fex2.identity_model
+    assert fex1.inputs.values[0] == fex2.inputs.values[0]
+    assert len(fex1.facebox_columns) == len(fex2.facebox_columns)
+    assert len(fex1.emotion_columns) == len(fex2.emotion_columns)
+    assert len(fex1.au_columns) == len(fex2.au_columns)
+    assert len(fex1.landmark_columns) == len(fex2.landmark_columns)
+    assert len(fex1.identity_columns) == len(fex2.identity_columns)
+    assert fex1.aus['AU01'].values[0] == fex2.aus['AU01'].values[0]
+    
+    
 def test_stats():
     filename = os.path.join(get_test_data_path(), "OpenFace_Test.csv")
     openface = Fex(filename=filename, sampling_freq=30, detector="OpenFace")

--- a/feat/utils/io.py
+++ b/feat/utils/io.py
@@ -80,38 +80,45 @@ def download_url(*args, **kwargs):
     with open(os.devnull, "w") as f, contextlib.redirect_stdout(f):
         return tv_download_url(*args, **kwargs)
 
-def read_fex(file_name, file_type='py-feat'):
-    '''Load a Fex file with JSON metadata
-    
+
+def read_fex(file_name, file_type="py-feat"):
+    """Load a Fex file with JSON metadata
+
     Args:
         file_name: (str) name file to load
-        file_type: (str) type of file to load ['py-feat', 'openface'] 
+        file_type: (str) type of file to load ['py-feat', 'openface']
     Returns:
         fex data instance
-    
-    '''
 
-    if file_type == 'py-feat':
-        with open(file_name, 'r') as f:
+    """
+
+    if file_type == "py-feat":
+        with open(file_name, "r") as f:
             first_line = f.readline().strip()
-            if first_line.startswith('#'):
+            if first_line.startswith("#"):
                 meta_json = first_line[1:].strip()
                 meta_dict = json.loads(meta_json)
-                if 'fex_columns' in meta_dict:
-                    del meta_dict['fex_columns']
+                if "fex_columns" in meta_dict:
+                    del meta_dict["fex_columns"]
             else:
-                raise ValueError("The file does not contain metadata as expected. Use pd.read_csv to load this file.")
-        
-        df = pd.read_csv(file_name, comment='#')
-        return feat.Fex(df, **meta_dict)
-        
-    elif file_type == 'openface':
-        raise NotImplementedError('Only py-feat files can currently be opened using this function try read_openface for now.')
-    
-    else:
-        raise NotImplementedError('Only py-feat and openface files can currently be opened using this function')
+                raise ValueError(
+                    "The file does not contain metadata as expected. Use pd.read_csv to load this file."
+                )
 
-    
+        df = pd.read_csv(file_name, comment="#")
+        return feat.Fex(df, **meta_dict)
+
+    elif file_type == "openface":
+        raise NotImplementedError(
+            "Only py-feat files can currently be opened using this function try read_openface for now."
+        )
+
+    else:
+        raise NotImplementedError(
+            "Only py-feat and openface files can currently be opened using this function"
+        )
+
+
 # DEPRECATE
 def read_feat(fexfile):
     """This function reads files extracted using the Detector from the Feat package.
@@ -123,7 +130,7 @@ def read_feat(fexfile):
         Fex of processed facial expressions
     """
     warnings.warn(
-            "This function is deprecated use read_fex instead", DeprecationWarning
+        "This function is deprecated use read_fex instead", DeprecationWarning
     )
     d = pd.read_csv(fexfile)
     au_columns = [col for col in d.columns if "AU" in col]
@@ -139,6 +146,7 @@ def read_feat(fexfile):
         detector="Feat",
     )
     return fex
+
 
 # TODO add this functionality to read_fex
 def read_openface(openfacefile, features=None):

--- a/feat/utils/io.py
+++ b/feat/utils/io.py
@@ -18,7 +18,6 @@ from feat.utils import (
     openface_time_columns,
 )
 import json
-
 from torchvision.datasets.utils import download_url as tv_download_url
 
 __all__ = [
@@ -26,6 +25,7 @@ __all__ = [
     "get_test_data_path",
     "validate_input",
     "download_url",
+    "read_fex",
     "read_openface",
 ]
 
@@ -103,7 +103,7 @@ def read_fex(file_name, file_type='py-feat'):
                 raise ValueError("The file does not contain metadata as expected. Use pd.read_csv to load this file.")
         
         df = pd.read_csv(file_name, comment='#')
-        return Fex(df, **meta_dict)
+        return feat.Fex(df, **meta_dict)
         
     elif file_type == 'openface':
         raise NotImplementedError('Only py-feat files can currently be opened using this function try read_openface for now.')


### PR DESCRIPTION
This PR streamlines how Fex files are written out and imported using `read_fex` and `Fex.write`.

We now include the Fex metadata in reading and writing operations as discussed in issue #212