### PR TITLE
Replace deprecated simps function with simpson from scipy.integrate

### DIFF
--- a/feat/utils/stats.py
+++ b/feat/utils/stats.py
@@ -4,7 +4,7 @@ Feat utility and helper functions for performing statistics.
 
 import numpy as np
 import pandas as pd
-from scipy.integrate import simps
+from scipy.integrate import simpson
 import torch
 from torch.nn.functional import cosine_similarity
 
@@ -61,7 +61,7 @@ def calc_hist_auc(vals, hist_range=None):
         else:
             cross = vals[crossings[i] : crossings[i + 1]]
         if cross:
-            auc = simps(cross)
+            auc = simpson(cross)
             if auc > 0:
                 pos.append(auc)
             elif auc < 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=1.0
-numpy>=1.9
+numpy<2
 seaborn>=0.7.0
 matplotlib>=2.1
 nltools>=0.5.1


### PR DESCRIPTION
Recently, the deprecated `simps` function from `scipy.integrate` has been removed (in this pull request [#20278](https://github.com/scipy/scipy/pull/20278)). This causes errors when using a version released after the above-mentioned pull request.

Additionally, there was a recent update to NumPy that caused issues while running tests in `feat/tests`, so I have ensured that versions above 2.0 are not installed by modifying the `requirements.txt` file.

I hope I have been helpful.