### PR TITLE
Fix device mismatches blocking device='mps'

### DIFF
--- a/feat/detector.py
+++ b/feat/detector.py
@@ -314,7 +314,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
 
         # img2pose
         frames = convert_image_to_tensor(images, img_type="float32") / 255.0
-        frames.to(self.device)
+        frames = frames.to(self.device)
 
         batch_results = []
         for i in range(frames.size(0)):

--- a/feat/facepose_detectors/img2pose/img2pose_test.py
+++ b/feat/facepose_detectors/img2pose/img2pose_test.py
@@ -314,12 +314,10 @@ class Img2Pose:
             dict: A dictionary of bboxes and poses
 
         """
-        # For device='mps'
-        # Uncommenting this line at least gets img2pose running but errors with
-        # Error: command buffer exited with error status.
-        # The Metal Performance Shaders operations encoded on it may not have completed.
-
-        # img = img.to(self.device)
+        # Move the image to the same device as the model. Required when
+        # device='mps' or 'cuda' — the upstream `convert_image_to_tensor`
+        # produces a CPU tensor regardless of the detector's device.
+        img = img.to(self.device)
 
         # Obtain prediction
         with torch.no_grad():

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -402,6 +402,11 @@ def align_face(img, landmarks, landmark_type=68, box_enlarge=2.5, img_size=112):
     if img.ndim == 3:
         img = img[None, :]
 
+    # warp_affine internally builds a sampling grid that must live on
+    # the same device as the input. When img is on mps/cuda this raises
+    # grid_sampler device mismatch unless the matrix is moved too.
+    affine_matrix = affine_matrix.to(img.device)
+
     aligned_img = warp_affine(
         img,
         affine_matrix,
@@ -776,7 +781,8 @@ def mask_image(img, mask):
     #     raise ValueError(
     #         f"img must be pytorch tensor, not {type(img)} and mask must be np array not {type(mask)}"
     #     )
-    return torch.sgn(torch.tensor(mask).to(torch.float32)).unsqueeze(0).unsqueeze(0) * img
+    mask_t = torch.tensor(mask).to(torch.float32).to(img.device)
+    return torch.sgn(mask_t).unsqueeze(0).unsqueeze(0) * img
 
 
 def convert_to_euler(rotvec, is_rotvec=True):


### PR DESCRIPTION
## Summary

Three places in the inference path created tensors on CPU while the
model weights were on the user-selected device (`mps` or `cuda`),
causing `Detector(device='mps').detect(...)` to crash partway through.

After these fixes, end-to-end MPS detection runs cleanly on Apple
Silicon. Outputs match CPU within floating-point tolerance.

## What was broken

```
Detector(device='mps')
  ↳ detect_image
    ↳ img2pose forward                  → input(cpu) vs weight(mps)
                                          (slow_conv2d_forward_mps)
    ↳ align_face → kornia.warp_affine   → grid_sampler device mismatch
    ↳ mask_image (in extract_hog_*)     → tensor(cpu) * img(mps)
```

## Fixes

| File | Line | Change |
|---|---|---|
| `feat/detector.py` | 317 | `frames.to(self.device)` was a no-op (return value discarded). `tensor.to()` is **not** in-place; only `nn.Module.to()` is. Replaced with `frames = frames.to(self.device)`. |
| `feat/facepose_detectors/img2pose/img2pose_test.py` | 322 | Uncommented the `img = img.to(self.device)` device hand-off. The previous comment cited Metal command-buffer errors; those don't reproduce on PyTorch ≥ 2.4 with current MPS, and without this line img2pose can never run on a non-CPU device. |
| `feat/utils/image_operations.py` | 405, 784 | `align_face` builds an affine matrix on CPU; `mask_image` builds a torch.tensor mask on CPU. Both now `.to(img.device)` before the kornia/torch ops that require co-located tensors. |

## Test plan

- [x] `Detector(device='cpu')` still works (no behavioral change)
- [x] `Detector(device='mps').detect('image.jpg', data_type='image')` runs end to end on Apple Silicon, returns identical schema and approximately equal numeric outputs to CPU
- [ ] (Reviewer) confirm `device='cuda'` still works on a CUDA box — these fixes are device-agnostic but the existing code only crashed on MPS because of CUDA's more permissive autograd
- [ ] (Reviewer) consider whether to similarly audit `detect_video`'s tensor flow once `detect_image` is verified

## Note on speed

These fixes make MPS *work* but don't necessarily make py-feat *faster* than CPU on M-series chips. On an M-class with no CPU contention, `detect_image` runs roughly comparably between CPU and MPS — the bottleneck is HoG features + XGBoost AUs (CPU-only) and not the neural-net forward passes. The fixes are still necessary to unblock anyone running `device='mps'` and to produce correct results on CUDA boxes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)