### PR TITLE
Detector / MPDetector correctness fixes from code review

### DIFF
--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -568,7 +568,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                     raise ValueError(f"{au_model} is not currently supported.")
             else:
                 raise ValueError(
-                    "Landmark Detector is required for AU Detection with {au_model}."
+                    f"Landmark Detector is required for AU Detection with {au_model}."
                 )
         else:
             self.au_detector = None

--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -515,7 +515,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
 
                 self.face_detector = RetinaFace(cfg=self.face_config, phase="test")
             else:
-                raise ValueError("{face_model} is not currently supported.")
+                raise ValueError(f"{face_model} is not currently supported.")
 
             self.face_detector.load_state_dict(face_checkpoint)
             self.face_detector.eval()
@@ -541,7 +541,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                 self.landmark_detector.to(self.device)
                 # self.landmark_detector = torch.compile(self.landmark_detector)
             else:
-                raise ValueError("{landmark_model} is not currently supported.")
+                raise ValueError(f"{landmark_model} is not currently supported.")
 
         else:
             self.face_size = 112
@@ -562,9 +562,10 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                         au_model_path, map_location=device, weights_only=True
                     )
                     self.au_detector.load_state_dict(au_checkpoint)
+                    self.au_detector.eval()
                     self.au_detector.to(self.device)
                 else:
-                    raise ValueError("{au_model} is not currently supported.")
+                    raise ValueError(f"{au_model} is not currently supported.")
             else:
                 raise ValueError(
                     "Landmark Detector is required for AU Detection with {au_model}."
@@ -628,7 +629,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                     )
 
             else:
-                raise ValueError("{emotion_model} is not currently supported.")
+                raise ValueError(f"{emotion_model} is not currently supported.")
         else:
             self.emotion_detector = None
 
@@ -658,7 +659,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                 self.identity_detector.to(self.device)
                 # self.identity_detector = torch.compile(self.identity_detector)
             else:
-                raise ValueError("{identity_model} is not currently supported.")
+                raise ValueError(f"{identity_model} is not currently supported.")
         else:
             self.identity_detector = None
 
@@ -700,7 +701,6 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
 
                 bbox = face_output["boxes"]
                 facescores = face_output["scores"]
-                _ = face_output["landmarks"]
 
             # Extract faces from bbox
             if bbox.numel() != 0:
@@ -1032,7 +1032,9 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                     # batch_results.loc[batch_results['frame']==frame_idx, f'z_{i}'] = (batch_results.loc[batch_results['frame']==frame_idx, f'z_{i}'] - batch_data["Padding"]["Top"].detach().numpy()[j])/batch_data["Scale"].detach().numpy()[j]
 
             batch_output.append(batch_results)
-            frame_counter += 1 * batch_size
+            # Use the actual batch size (may be smaller than `batch_size` for the
+            # last batch when len(dataset) is not divisible by batch_size).
+            frame_counter += batch_data["Image"].shape[0]
         batch_output = pd.concat(batch_output)
         batch_output.reset_index(drop=True, inplace=True)
         if data_type.lower() == "video":

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -161,7 +161,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                     landmark_model_file, map_location=self.device, weights_only=True
                 )["state_dict"]  # Ensure Model weights are Float32 for MPS
             else:
-                raise ValueError("{landmark_model} is not currently supported.")
+                raise ValueError(f"{landmark_model} is not currently supported.")
             self.landmark_detector.load_state_dict(landmark_state_dict)
             self.landmark_detector.eval()
             self.landmark_detector.to(self.device)
@@ -189,7 +189,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                         cache_dir=get_resource_path(),
                     )
                 else:
-                    raise ValueError("{au_model} is not currently supported.")
+                    raise ValueError(f"{au_model} is not currently supported.")
 
                 au_unknown_types = get_untrusted_types(file=au_model_path)
                 loaded_au_model = load(au_model_path, trusted=au_unknown_types)
@@ -262,7 +262,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                     )
 
             else:
-                raise ValueError("{emotion_model} is not currently supported.")
+                raise ValueError(f"{emotion_model} is not currently supported.")
         else:
             self.emotion_detector = None
 
@@ -292,7 +292,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                 self.identity_detector.to(self.device)
                 # self.identity_detector = torch.compile(self.identity_detector)
             else:
-                raise ValueError("{identity_model} is not currently supported.")
+                raise ValueError(f"{identity_model} is not currently supported.")
         else:
             self.identity_detector = None
 
@@ -394,7 +394,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                 landmarks = self.landmark_detector.forward(
                     extracted_faces.to(self.device)
                 )
-            if self.info["landmark_model"].lower() == "mobilefacenet":
+            elif self.info["landmark_model"].lower() == "mobilefacenet":
                 landmarks = self.landmark_detector.forward(
                     extracted_faces.to(self.device)
                 )[0]
@@ -676,7 +676,9 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                 batch_results.to_csv(save, mode="a", index=False, header=batch_id == 0)
             else:
                 batch_output.append(batch_results)
-            frame_counter += 1 * batch_size
+            # Use the actual batch size (may be smaller than `batch_size` for the
+            # last batch when len(dataset) is not divisible by batch_size).
+            frame_counter += batch_data["Image"].shape[0]
 
         batch_output = (
             Fex(

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -204,7 +204,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                 )
             else:
                 raise ValueError(
-                    "Landmark Detector is required for AU Detection with {au_model}."
+                    f"Landmark Detector is required for AU Detection with {au_model}."
                 )
         else:
             self.au_detector = None


### PR DESCRIPTION
## Summary

Five small, contained fixes from the structured code review of \`detector.py\` and \`MPDetector.py\`. Three of them are correctness bugs that silently produced wrong outputs; two are cleanups.

| # | File:line | Class | What |
|---|---|---|---|
| 1 | detector.py:397 | **Correctness** | mobilenet landmark forward ran twice; final output was un-normalized (wrong landmarks) |
| 2 | MPDetector.py:565 | **Correctness** | au_detector loaded but never put in \`eval()\` — dropout/batchnorm wrong at inference |
| 3 | detector.py:679 + MPDetector.py:1035 | **Correctness** | \`frame_counter += 1 * batch_size\` doesn't account for a smaller final batch; off-by-N frame numbering when len(dataset) is not divisible by batch_size |
| 4 | MPDetector.py:703 | Cleanup | dead read \`_ = face_output[\"landmarks\"]\` |
| 5 | detector.py + MPDetector.py (9 sites) | Cleanup | \`raise ValueError(\"{landmark_model} ...\")\` missing \`f\` prefix, rendered literal placeholders |

## How #1 was found

The code-review agent flagged the missing \`elif\`. Verified by reading the source: lines 389-404 had \`if mobilenet:\` followed by \`if mobilefacenet:\` (not elif). When mobilenet was selected, the else of the second \`if\` *also* matched (since not-mobilefacenet was true), and re-ran landmark inference on the already-normalized faces, overwriting the correct output. So mobilenet has been silently producing wrong landmarks for any user who explicitly selected \`landmark_model='mobilenet'\`.

## Test plan

- [x] \`py_compile\` clean for both files.
- [ ] (Reviewer) confirm AU outputs differ between this and main on a fixed input when \`au_model='mp_blendshapes'\` (eval-mode dropout difference). Likely small.
- [ ] (Reviewer) confirm landmarks improve on a single image when \`landmark_model='mobilenet'\` is selected (no longer running un-normalized forward).

## What's NOT in this PR

Bigger items from the code review (Detector/MPDetector consolidation, hoist \`compute_original_image_size\` from the per-frame loop, fix the wrong loss in \`MPDetector.estimate_face_pose\` — superseded by PR #261, vectorize the per-row \`.loc[mask, col]\` post-processing) are deferred to their own PRs since they need broader changes and parity tests.

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)