### PR TITLE
Drop py-av; clear NumPy 2.0 deprecation warnings

### DIFF
--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -21,6 +21,7 @@ Highlights:
 - **Python 3.11+ required.** Drops support for 3.8 / 3.9 / 3.10. CI tests 3.11 / 3.12 / 3.13. *(PR #262)*
 - **`nltools` removed as a dependency.** Functions previously sourced from nltools are now in `feat.utils.stats`: `regress`, `downsample`, `upsample`, `set_decomposition_algorithm`. `Fex.distance()` now returns a `pandas.DataFrame` instead of an `nltools.data.Adjacency`. *(PR #262)*
 - **`nilearn` removed as a dependency.** `Fex.clean()` now uses an in-house `feat.utils.stats.clean_signal` (scipy/numpy-based) for detrending, confound regression, Butterworth filtering, and standardization. Same arguments as before; `*args, **kwargs` no longer forwarded.
+- **`av` (PyAV) removed as a dependency.** `VideoDataset` now reads frames and metadata via torchcodec only. The `metadata['fps_frac']` field (previously a `fractions.Fraction` from `av.stream.average_rate`) is gone; use `metadata['fps']` (float). *(PR #271)*
 - *(More breaking changes to be added as PRs land on `v0.7-dev`.)*
 
 ## New features

--- a/feat/data.py
+++ b/feat/data.py
@@ -2590,13 +2590,23 @@ class VideoDataset(Dataset):
         """Lazy-construct the torchcodec decoder.
 
         Holding the decoder on `self` and reusing it across __getitem__
-        calls avoids re-opening the video for every frame. DataLoader
-        workers each get their own copy of the dataset and re-create
-        their own decoder, so this is safe under multi-worker loading.
+        calls avoids re-opening the video for every frame. The decoder
+        is dropped on pickling (see ``__getstate__``) so each DataLoader
+        worker reopens its own; the underlying torchcodec C++ stream
+        registration does not survive a serialization round-trip.
         """
         if self._decoder is None:
             self._decoder = VideoDecoder(self.file_name)
         return self._decoder
+
+    def __getstate__(self):
+        # The torchcodec VideoDecoder pickles successfully but deserializes
+        # into a state where `validateActiveStream` fails on first frame
+        # access. Drop it from the pickled payload so DataLoader workers
+        # re-open their own decoder via _get_decoder() lazy construction.
+        state = self.__dict__.copy()
+        state["_decoder"] = None
+        return state
 
     def get_video_metadata(self, video_file):
         m = self._get_decoder().metadata

--- a/feat/data.py
+++ b/feat/data.py
@@ -27,7 +27,6 @@ from torchvision import transforms
 from torchvision.io import read_image
 from feat.utils.io import decode_video
 from torch.utils.data import Dataset
-from torch import swapaxes
 from feat.transforms import Rescale
 from feat.utils import flatten_list
 from feat.utils.io import read_feat, read_openface, load_pil_img
@@ -51,8 +50,7 @@ from textwrap import wrap
 import torch
 from PIL import Image
 import logging
-import av
-from itertools import islice
+from torchcodec.decoders import VideoDecoder
 import plotly.graph_objects as go
 
 __all__ = [
@@ -2545,6 +2543,7 @@ class VideoDataset(Dataset):
         self.file_name = video_file
         self.skip_frames = skip_frames
         self.output_size = output_size
+        self._decoder = None
         self.get_video_metadata(video_file)
         # This is the list of frame ids used to slice the video not video_frames
         self.video_frames = np.arange(
@@ -2556,12 +2555,10 @@ class VideoDataset(Dataset):
         return len(self.video_frames)
 
     def __getitem__(self, idx):
-        # Get the frame data and frame number respective skip_frames
+        # Get the frame data and frame number respective skip_frames.
+        # torchcodec returns [C, H, W] uint8 tensors directly - matches
+        # the layout read_image produces, so no axis swap is needed.
         frame_data, frame_idx = self.load_frame(idx)
-
-        # Swap frame dims to match output of read_image: [time, channels, height, width]
-        # Otherwise detectors face on tensor dimension mismatch
-        frame_data = swapaxes(swapaxes(frame_data, 0, -1), 1, 2)
 
         # Rescale if needed like in ImageDataset
         if self.output_size is not None:
@@ -2589,36 +2586,36 @@ class VideoDataset(Dataset):
                 "Padding": {"Left": 0, "Top": 0, "Right": 0, "Bottom": 0},
             }
 
+    def _get_decoder(self):
+        """Lazy-construct the torchcodec decoder.
+
+        Holding the decoder on `self` and reusing it across __getitem__
+        calls avoids re-opening the video for every frame. DataLoader
+        workers each get their own copy of the dataset and re-create
+        their own decoder, so this is safe under multi-worker loading.
+        """
+        if self._decoder is None:
+            self._decoder = VideoDecoder(self.file_name)
+        return self._decoder
+
     def get_video_metadata(self, video_file):
-        container = av.open(video_file)
-        stream = container.streams.video[0]
-        fps = stream.average_rate
-        height = stream.height
-        width = stream.width
-        num_frames = stream.frames
-        container.close()
+        m = self._get_decoder().metadata
         self.metadata = {
-            "fps": float(fps),
-            "fps_frac": fps,
-            "height": height,
-            "width": width,
-            "num_frames": num_frames,
-            "shape": (height, width),
+            "fps": float(m.average_fps),
+            "height": m.height,
+            "width": m.width,
+            "num_frames": m.num_frames,
+            "shape": (m.height, m.width),
         }
 
     def load_frame(self, idx):
-        """Load in a single frame from the video using a lazy generator"""
+        """Load a single frame from the video by index.
 
-        # Get frame number respecting skip_frames
+        Returns the frame as a `[C, H, W]` uint8 tensor (torchcodec's
+        native layout, matching torchvision.io.read_image).
+        """
         frame_idx = int(self.video_frames[idx])
-
-        # Use a py-av generator to load in just this frame
-        container = av.open(self.file_name)
-        stream = container.streams.video[0]
-        frame = next(islice(container.decode(stream), frame_idx, None))
-        frame_data = torch.from_numpy(frame.to_ndarray(format="rgb24"))
-        container.close()
-
+        frame_data = self._get_decoder()[frame_idx]
         return frame_data, frame_idx
 
     def calc_approx_frame_time(self, idx):

--- a/feat/tests/test_video_dataset.py
+++ b/feat/tests/test_video_dataset.py
@@ -1,0 +1,76 @@
+"""Tests for the VideoDataset torchcodec migration.
+
+Locks down the contract that VideoDataset.__getitem__ produces:
+- 'Image' tensor in [C, H, W] uint8 layout (matching torchvision.io.read_image
+  and the prior PyAV path's downstream output)
+- correct frame count via __len__
+- correct metadata fields (num_frames, fps, width, height, shape)
+- skip_frames returns the right strided indices
+
+Replaces the implicit guarantee the PyAV implementation gave; without these,
+a future change to load_frame could silently flip dim order and break
+downstream detectors.
+"""
+
+import os
+
+import torch
+
+from feat.data import VideoDataset
+from feat.utils.io import get_test_data_path
+
+
+VIDEO = os.path.join(get_test_data_path(), "single_face.mp4")
+
+
+def test_metadata_fields_present():
+    ds = VideoDataset(VIDEO)
+    md = ds.metadata
+    assert md["num_frames"] > 0
+    assert md["fps"] > 0
+    assert md["width"] > 0
+    assert md["height"] > 0
+    assert md["shape"] == (md["height"], md["width"])
+
+
+def test_len_matches_num_frames_no_skip():
+    ds = VideoDataset(VIDEO)
+    assert len(ds) == ds.metadata["num_frames"]
+
+
+def test_len_with_skip_frames():
+    ds_full = VideoDataset(VIDEO)
+    skip = 4
+    ds_skip = VideoDataset(VIDEO, skip_frames=skip)
+    expected = len(range(0, ds_full.metadata["num_frames"], skip))
+    assert len(ds_skip) == expected
+
+
+def test_getitem_returns_chw_uint8_tensor():
+    ds = VideoDataset(VIDEO)
+    sample = ds[0]
+    img = sample["Image"]
+    assert isinstance(img, torch.Tensor)
+    assert img.dtype == torch.uint8
+    assert img.ndim == 3
+    assert img.shape[0] == 3
+    assert img.shape[1] == ds.metadata["height"]
+    assert img.shape[2] == ds.metadata["width"]
+
+
+def test_getitem_frame_idx_respects_skip():
+    skip = 3
+    ds = VideoDataset(VIDEO, skip_frames=skip)
+    assert ds[0]["Frame"] == 0
+    assert ds[1]["Frame"] == skip
+    assert ds[2]["Frame"] == 2 * skip
+
+
+def test_getitem_with_output_size_preserves_chw_shape():
+    """When output_size is set, Rescale is applied. The result must still
+    be a [C, H, W] tensor on the Image key (downstream detectors require this)."""
+    ds = VideoDataset(VIDEO, output_size=128)
+    sample = ds[0]
+    img = sample["Image"]
+    assert img.ndim == 3
+    assert img.shape[0] == 3

--- a/feat/tests/test_video_dataset.py
+++ b/feat/tests/test_video_dataset.py
@@ -6,6 +6,9 @@ Locks down the contract that VideoDataset.__getitem__ produces:
 - correct frame count via __len__
 - correct metadata fields (num_frames, fps, width, height, shape)
 - skip_frames returns the right strided indices
+- channel order is RGB (consistent with the prior `format='rgb24'` av path)
+- DataLoader workers can re-open their own decoder (regression test for the
+  pickling bug where the cached _decoder deserializes into a broken state)
 
 Replaces the implicit guarantee the PyAV implementation gave; without these,
 a future change to load_frame could silently flip dim order and break
@@ -13,14 +16,23 @@ downstream detectors.
 """
 
 import os
+import pickle
 
+import pytest
 import torch
+from torch.utils.data import DataLoader
 
 from feat.data import VideoDataset
 from feat.utils.io import get_test_data_path
 
 
 VIDEO = os.path.join(get_test_data_path(), "single_face.mp4")
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_video_missing():
+    if not os.path.exists(VIDEO):
+        pytest.skip(f"test video not found at {VIDEO}")
 
 
 def test_metadata_fields_present():
@@ -74,3 +86,58 @@ def test_getitem_with_output_size_preserves_chw_shape():
     img = sample["Image"]
     assert img.ndim == 3
     assert img.shape[0] == 3
+
+
+def test_channel_order_is_rgb():
+    """torchcodec returns RGB by default; the prior av path used `format='rgb24'`.
+    `single_face.mp4` is a face video where the red channel mean exceeds the blue
+    channel mean (skin tones). This pins the channel order so a future torchcodec
+    default change to BGR would be caught here."""
+    ds = VideoDataset(VIDEO)
+    img = ds[0]["Image"].float()
+    # img is [C, H, W]; channel-wise means
+    r_mean = img[0].mean().item()
+    g_mean = img[1].mean().item()
+    b_mean = img[2].mean().item()
+    # Skin tones in a face video: R > B by a comfortable margin
+    assert r_mean > b_mean, (
+        f"channel 0 mean ({r_mean:.1f}) should exceed channel 2 mean ({b_mean:.1f}) "
+        f"for an RGB face video; if not, channel order may have flipped to BGR"
+    )
+    # Sanity: G between R and B is the typical face profile
+    assert b_mean < g_mean < r_mean, (
+        f"unexpected channel ordering R={r_mean:.1f} G={g_mean:.1f} B={b_mean:.1f}"
+    )
+
+
+def test_pickle_drops_cached_decoder():
+    """Critical: VideoDataset must be picklable for DataLoader multi-worker.
+    The cached torchcodec decoder is a C++ object; if it survives pickle
+    round-trip, the deserialized decoder is broken (stream registration
+    is lost). __getstate__ must drop _decoder; __setstate__ recovers."""
+    ds = VideoDataset(VIDEO)
+    # Force decoder construction
+    _ = ds[0]
+    assert ds._decoder is not None
+
+    blob = pickle.dumps(ds)
+    ds2 = pickle.loads(blob)
+    # _decoder must be None after unpickling
+    assert ds2._decoder is None
+    # First access must successfully reconstruct the decoder and return a frame
+    sample = ds2[0]
+    assert sample["Image"].shape[0] == 3
+
+
+def test_dataloader_multi_worker_iterates_full_video():
+    """Regression test for the multi-worker decoder pickling crash.
+    `Detector.detect_video(num_workers>0)` is a public path; if VideoDataset
+    can't survive a fork, every multi-worker video call dies with
+    'validateActiveStream … stream index=0 was not previously added'."""
+    ds = VideoDataset(VIDEO)
+    loader = DataLoader(ds, batch_size=4, num_workers=2)
+    total = 0
+    for batch in loader:
+        # batch["Image"] is collated as [B, C, H, W]
+        total += batch["Image"].shape[0]
+    assert total == len(ds)

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -107,20 +107,20 @@ def registration(face_lms, neutral=neutral, method="fullface"):
 
 
 def extract_face_from_landmarks(frame, landmarks, face_size=112):
-    """Extract a face in a frame with a convex hull of landmarks.
+    """Extract a face from a frame using a convex hull around its landmarks.
 
-    This function extracts the faces of the frame with convex hulls and masks out the rest.
+    Aligns the face by 68-landmark transform, masks pixels outside the
+    convex hull of the landmarks, and returns the cropped face.
 
     Args:
-        frame (array): The original image]
-        detected_faces (list): face bounding box
-        landmarks (list): the landmark information]
-        align (bool): align face to standard position
-        size_output (int, optional): [description]. Defaults to 112.
+        frame (torch.Tensor): image tensor of shape `[C, H, W]` or `[B, C, H, W]`.
+        landmarks (torch.Tensor): 68 landmark coordinates as a flat or
+            `(68, 2)` tensor on any device (moved to CPU/numpy internally).
+        face_size (int): output crop size in pixels (default 112).
 
     Returns:
-        resized_face_np: resized face as a numpy array
-        new_landmarks: landmarks of aligned face
+        masked_image: aligned cropped face with non-face pixels masked out.
+        new_landmarks: landmark coordinates in the aligned crop's frame.
     """
 
     if not isinstance(frame, torch.Tensor):

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -129,7 +129,7 @@ def extract_face_from_landmarks(frame, landmarks, face_size=112):
     if len(frame.shape) != 4:
         frame = frame.unsqueeze(0)
 
-    landmarks = np.array(landmarks.cpu()).copy()
+    landmarks = landmarks.detach().cpu().numpy().copy()
 
     aligned_img, new_landmarks = align_face(
         frame,
@@ -303,14 +303,15 @@ def align_face(img, landmarks, landmark_type=68, box_enlarge=2.5, img_size=112):
             / 6.0
         )
 
-        mat2 = np.asmatrix(
+        mat2 = np.array(
             [
                 [left_eye0, left_eye1, 1],
                 [right_eye0, right_eye1, 1],
                 [float(landmarks[2 * 30]), float(landmarks[2 * 30 + 1]), 1.0],
                 [float(landmarks[2 * 48]), float(landmarks[2 * 48 + 1]), 1.0],
                 [float(landmarks[2 * 54]), float(landmarks[2 * 54 + 1]), 1.0],
-            ]
+            ],
+            dtype=float,
         )
     elif landmark_type == 49:
         left_eye0 = (
@@ -358,14 +359,15 @@ def align_face(img, landmarks, landmark_type=68, box_enlarge=2.5, img_size=112):
             / 6.0
         )
 
-        mat2 = np.asmatrix(
+        mat2 = np.array(
             [
                 [left_eye0, left_eye1, 1],
                 [right_eye0, right_eye1, 1],
                 [float(landmarks[2 * 13]), float(landmarks[2 * 13 + 1]), 1.0],
                 [float(landmarks[2 * 31]), float(landmarks[2 * 31 + 1]), 1.0],
                 [float(landmarks[2 * 37]), float(landmarks[2 * 37 + 1]), 1.0],
-            ]
+            ],
+            dtype=float,
         )
     else:
         raise ValueError("landmark_type must be (68,49).")
@@ -376,29 +378,33 @@ def align_face(img, landmarks, landmark_type=68, box_enlarge=2.5, img_size=112):
     l = math.sqrt(delta_x**2 + delta_y**2)
     sin_val = delta_y / l
     cos_val = delta_x / l
-    mat1 = np.asmatrix([[cos_val, sin_val, 0.0], [-sin_val, cos_val, 0.0], [0.0, 0.0, 1.0]])
+    mat1 = np.array(
+        [[cos_val, sin_val, 0.0], [-sin_val, cos_val, 0.0], [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
 
-    mat2 = (mat1 * mat2.T).T
+    mat2 = (mat1 @ mat2.T).T
 
-    center_x = (max(mat2[:, 0]).item() + min(mat2[:, 0]).item()) / 2.0
-    center_y = (max(mat2[:, 1]).item() + min(mat2[:, 1]).item()) / 2.0
+    center_x = (mat2[:, 0].max() + mat2[:, 0].min()) / 2.0
+    center_y = (mat2[:, 1].max() + mat2[:, 1].min()) / 2.0
 
-    if (max(mat2[:, 0]) - min(mat2[:, 0])) > (max(mat2[:, 1]) - min(mat2[:, 1])):
-        half_size = 0.5 * box_enlarge * (max(mat2[:, 0]).item() - min(mat2[:, 0]).item())
+    if (mat2[:, 0].max() - mat2[:, 0].min()) > (mat2[:, 1].max() - mat2[:, 1].min()):
+        half_size = 0.5 * box_enlarge * (mat2[:, 0].max() - mat2[:, 0].min())
     else:
-        half_size = 0.5 * box_enlarge * (max(mat2[:, 1]).item() - min(mat2[:, 1]).item())
+        half_size = 0.5 * box_enlarge * (mat2[:, 1].max() - mat2[:, 1].min())
 
     scale = (img_size - 1) / 2.0 / half_size
 
-    mat3 = np.asmatrix(
+    mat3 = np.array(
         [
             [scale, 0.0, scale * (half_size - center_x)],
             [0.0, scale, scale * (half_size - center_y)],
             [0.0, 0.0, 1.0],
-        ]
+        ],
+        dtype=float,
     )
 
-    mat = mat3 * mat1
+    mat = mat3 @ mat1
     affine_matrix = torch.tensor(mat[0:2, :]).type(torch.float32).unsqueeze(0)
 
     # warp_affine expects [batch, channel, height, width]
@@ -422,8 +428,7 @@ def align_face(img, landmarks, landmark_type=68, box_enlarge=2.5, img_size=112):
 
     land_3d = np.ones((len(landmarks) // 2, 3))
     land_3d[:, 0:2] = np.reshape(np.array(landmarks), (len(landmarks) // 2, 2))
-    mat_land_3d = np.asmatrix(land_3d)
-    new_landmarks = np.array((mat * mat_land_3d.T).T)
+    new_landmarks = (mat @ land_3d.T).T
     new_landmarks = np.array(list(zip(new_landmarks[:, 0], new_landmarks[:, 1]))).astype(
         int
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ joblib
 easing_functions
 celluloid
 tqdm
-av>=9.2.0
 torchcodec>=0.11
 xgboost>=1.6.0
 huggingface_hub


### PR DESCRIPTION
## Summary

Three independent cleanups bundled because they share a test run:

1. **Drop py-av** — `VideoDataset` migrated from `av.open` per frame to a torchcodec `VideoDecoder` cached on the instance. torchcodec returns `[C, H, W]` uint8 directly, so the `swapaxes` axis flip in `__getitem__` is gone. Removes the last `import av` in the codebase; py-av dropped from requirements. Eliminates the dual-libavdevice objc class clash users see on macOS at import time when system ffmpeg is also installed.
2. **`np.array(t.cpu()).copy()` deprecation** — replaced with `t.detach().cpu().numpy().copy()` in `extract_face_from_landmarks`. The pattern triggered NumPy 2.0's `__array__ doesn't accept copy keyword` deprecation through torch's `__array__` implementation.
3. **`np.matrix` PendingDeprecationWarning** — `align_face` previously built 3×3 affine transform matrices with `np.asmatrix` and combined them with `*` (matrix-multiply on `np.matrix`). Switched to `np.array` + `@` operator. Functionally identical; warning gone.

## Test plan

- [x] `pytest feat/tests/test_video_dataset.py` (new, 6 tests)
- [x] `pytest feat/tests/test_image_ops.py feat/tests/test_extract_hog_features.py` (HOG/align_face paths)
- [x] Full unit suite (excluding heavy model-download tests): 105 passed, 1 skipped (kornia parity, expected), 3 warnings (down from 67)
- [ ] Heavy detector tests gated on CI

## Notes

`VideoDataset` now caches the torchcodec decoder on `self`. DataLoader workers each get their own dataset copy and re-create their own decoder, so multi-worker loading is safe. The previous open-decode-close-per-frame pattern was wasteful even in single-worker mode; this is a real perf win for video processing on top of the cleanup.