### PR TITLE
perf: defer Fex construction to end of detect() (+35% MPDetector)

### DIFF
--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -693,11 +693,10 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
-        # Return a plain pd.DataFrame, not a Fex. The Fex constructor's
-        # per-column attribute-setting loop (data.py:435 "Kludgy solution")
-        # is O(n_columns) and dominated this method's wall-time when called
-        # 30+ times per detect() with 1434 landmark columns. detect()
-        # collects these per-batch DataFrames and builds one Fex at the end.
+        # Return a plain pd.DataFrame; detect() wraps the concatenated
+        # result in a single Fex at the end. Avoids Fex.__init__'s
+        # O(n_columns) metadata loop (see Fex.__init__ in data.py) firing
+        # once per batch, which dominated wall-time on long videos.
         return pd.concat(
             [
                 feat_faceboxes,
@@ -811,12 +810,10 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             # last batch when len(dataset) is not divisible by batch_size).
             frame_counter += batch_data["Image"].shape[0]
         # Concatenate all batch DataFrames (cheap), then wrap in Fex once.
-        # Per-batch Fex construction was the dominant cost on long videos;
-        # see forward() docstring + data.py:435 for the underlying issue.
-        batch_output = pd.concat(batch_output)
-        batch_output.reset_index(drop=True, inplace=True)
+        # See forward() comment for why we don't wrap per batch.
+        concat_df = pd.concat(batch_output).reset_index(drop=True)
         batch_output = Fex(
-            batch_output,
+            concat_df,
             au_columns=AU_LANDMARK_MAP["Feat"],
             emotion_columns=FEAT_EMOTION_COLUMNS,
             facebox_columns=FEAT_FACEBOX_COLUMNS,

--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -693,32 +693,21 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
-        return Fex(
-            pd.concat(
-                [
-                    feat_faceboxes,
-                    feat_landmarks,
-                    feat_poses,
-                    feat_aus,
-                    feat_emotions,
-                    feat_identities,
-                ],
-                axis=1,
-            ),
-            au_columns=AU_LANDMARK_MAP["Feat"],
-            emotion_columns=FEAT_EMOTION_COLUMNS,
-            facebox_columns=FEAT_FACEBOX_COLUMNS,
-            landmark_columns=MP_LANDMARK_COLUMNS,
-            facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
-            gaze_columns=FEAT_GAZE_COLUMNS,
-            identity_columns=FEAT_IDENTITY_COLUMNS[1:],
-            detector="Feat",
-            face_model=self.info["face_model"],
-            landmark_model=self.info["landmark_model"],
-            au_model=self.info["au_model"],
-            emotion_model=self.info["emotion_model"],
-            facepose_model=self.info["facepose_model"],
-            identity_model=self.info["identity_model"],
+        # Return a plain pd.DataFrame, not a Fex. The Fex constructor's
+        # per-column attribute-setting loop (data.py:435 "Kludgy solution")
+        # is O(n_columns) and dominated this method's wall-time when called
+        # 30+ times per detect() with 1434 landmark columns. detect()
+        # collects these per-batch DataFrames and builds one Fex at the end.
+        return pd.concat(
+            [
+                feat_faceboxes,
+                feat_landmarks,
+                feat_poses,
+                feat_aus,
+                feat_emotions,
+                feat_identities,
+            ],
+            axis=1,
         )
 
     def detect(
@@ -821,8 +810,28 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             # Use the actual batch size (may be smaller than `batch_size` for the
             # last batch when len(dataset) is not divisible by batch_size).
             frame_counter += batch_data["Image"].shape[0]
+        # Concatenate all batch DataFrames (cheap), then wrap in Fex once.
+        # Per-batch Fex construction was the dominant cost on long videos;
+        # see forward() docstring + data.py:435 for the underlying issue.
         batch_output = pd.concat(batch_output)
         batch_output.reset_index(drop=True, inplace=True)
+        batch_output = Fex(
+            batch_output,
+            au_columns=AU_LANDMARK_MAP["Feat"],
+            emotion_columns=FEAT_EMOTION_COLUMNS,
+            facebox_columns=FEAT_FACEBOX_COLUMNS,
+            landmark_columns=MP_LANDMARK_COLUMNS,
+            facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
+            gaze_columns=FEAT_GAZE_COLUMNS,
+            identity_columns=FEAT_IDENTITY_COLUMNS[1:],
+            detector="Feat",
+            face_model=self.info["face_model"],
+            landmark_model=self.info["landmark_model"],
+            au_model=self.info["au_model"],
+            emotion_model=self.info["emotion_model"],
+            facepose_model=self.info["facepose_model"],
+            identity_model=self.info["identity_model"],
+        )
         if data_type.lower() == "video":
             batch_output["approx_time"] = [
                 dataset.calc_approx_frame_time(x)

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -612,31 +612,22 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
-        return Fex(
-            pd.concat(
-                [
-                    feat_faceboxes,
-                    feat_landmarks,
-                    feat_poses,
-                    feat_aus,
-                    feat_emotions,
-                    feat_identities,
-                ],
-                axis=1,
-            ),
-            au_columns=AU_LANDMARK_MAP["Feat"],
-            emotion_columns=FEAT_EMOTION_COLUMNS,
-            facebox_columns=FEAT_FACEBOX_COLUMNS,
-            landmark_columns=openface_2d_landmark_columns,
-            facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
-            identity_columns=FEAT_IDENTITY_COLUMNS[1:],
-            detector="Feat",
-            face_model=self.info["face_model"],
-            landmark_model=self.info["landmark_model"],
-            au_model=self.info["au_model"],
-            emotion_model=self.info["emotion_model"],
-            facepose_model=self.info["facepose_model"],
-            identity_model=self.info["identity_model"],
+        # Return a plain pd.DataFrame, not a Fex. The Fex constructor's
+        # per-column attribute-setting loop (data.py:435 "Kludgy solution")
+        # is O(n_columns) and is called once per batch by detect(); over a
+        # 472-frame video at batch=16 that adds up to seconds of pure
+        # pandas overhead. detect() collects per-batch DataFrames and wraps
+        # them in a single Fex at the end.
+        return pd.concat(
+            [
+                feat_faceboxes,
+                feat_landmarks,
+                feat_poses,
+                feat_aus,
+                feat_emotions,
+                feat_identities,
+            ],
+            axis=1,
         )
 
     def detect(
@@ -757,25 +748,31 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             # last batch when len(dataset) is not divisible by batch_size).
             frame_counter += batch_data["Image"].shape[0]
 
-        batch_output = (
-            Fex(
-                pd.read_csv(save),
-                au_columns=AU_LANDMARK_MAP["Feat"],
-                emotion_columns=FEAT_EMOTION_COLUMNS,
-                facebox_columns=FEAT_FACEBOX_COLUMNS,
-                landmark_columns=openface_2d_landmark_columns,
-                facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
-                identity_columns=FEAT_IDENTITY_COLUMNS[1:],
-                detector="Feat",
-                face_model=self.info["face_model"],
-                landmark_model=self.info["landmark_model"],
-                au_model=self.info["au_model"],
-                emotion_model=self.info["emotion_model"],
-                facepose_model=self.info["facepose_model"],
-                identity_model=self.info["identity_model"],
-            )
-            if save
-            else pd.concat(batch_output).reset_index(drop=True)
+        # Build a single Fex once - either by reading the streamed CSV
+        # (save mode) or by concatenating the per-batch DataFrames
+        # forward() now returns. Per-batch Fex construction was the
+        # dominant cost on long videos because Fex.__init__ runs an
+        # O(n_columns) loop (data.py:435 "Kludgy solution") on every
+        # call. Wrapping once amortizes that cost across all frames.
+        if save:
+            concat_df = pd.read_csv(save)
+        else:
+            concat_df = pd.concat(batch_output).reset_index(drop=True)
+        batch_output = Fex(
+            concat_df,
+            au_columns=AU_LANDMARK_MAP["Feat"],
+            emotion_columns=FEAT_EMOTION_COLUMNS,
+            facebox_columns=FEAT_FACEBOX_COLUMNS,
+            landmark_columns=openface_2d_landmark_columns,
+            facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
+            identity_columns=FEAT_IDENTITY_COLUMNS[1:],
+            detector="Feat",
+            face_model=self.info["face_model"],
+            landmark_model=self.info["landmark_model"],
+            au_model=self.info["au_model"],
+            emotion_model=self.info["emotion_model"],
+            facepose_model=self.info["facepose_model"],
+            identity_model=self.info["identity_model"],
         )
         if data_type.lower() == "video":
             batch_output["approx_time"] = [

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -612,12 +612,10 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
-        # Return a plain pd.DataFrame, not a Fex. The Fex constructor's
-        # per-column attribute-setting loop (data.py:435 "Kludgy solution")
-        # is O(n_columns) and is called once per batch by detect(); over a
-        # 472-frame video at batch=16 that adds up to seconds of pure
-        # pandas overhead. detect() collects per-batch DataFrames and wraps
-        # them in a single Fex at the end.
+        # Return a plain pd.DataFrame; detect() wraps the concatenated
+        # result in a single Fex at the end. Avoids Fex.__init__'s
+        # O(n_columns) metadata loop (see Fex.__init__ in data.py) firing
+        # once per batch, which dominated wall-time on long videos.
         return pd.concat(
             [
                 feat_faceboxes,
@@ -748,12 +746,9 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             # last batch when len(dataset) is not divisible by batch_size).
             frame_counter += batch_data["Image"].shape[0]
 
-        # Build a single Fex once - either by reading the streamed CSV
-        # (save mode) or by concatenating the per-batch DataFrames
-        # forward() now returns. Per-batch Fex construction was the
-        # dominant cost on long videos because Fex.__init__ runs an
-        # O(n_columns) loop (data.py:435 "Kludgy solution") on every
-        # call. Wrapping once amortizes that cost across all frames.
+        # Build a single Fex once: either from the streamed CSV (save
+        # mode) or by concatenating the per-batch DataFrames forward()
+        # returned. See forward() comment for why we don't wrap per batch.
         if save:
             concat_df = pd.read_csv(save)
         else:


### PR DESCRIPTION
## Summary

\`forward()\` in both \`Detector\` and \`MPDetector\` built a fresh \`Fex\` object every batch. The \`Fex.__init__\` has an O(n_columns) loop at \`data.py:435\` ("Kludgy solution") that materializes a Series for every column to copy two metadata attributes onto it. With MPDetector's 2024 columns × 30 batches per detect(), that loop was the single biggest cost in MPDetector's wall time.

This PR makes \`forward()\` return a plain \`pd.DataFrame\`; \`detect()\` keeps collecting per-batch DataFrames as before, then wraps the concatenated result in a single Fex once at the end. Same Fex output for users; same downstream methods.

## Measured on M5 MBP, MPS, batch 16, 472-frame video

| Config | Before ms/frame | After ms/frame | Gain |
|---|---|---|---|
| \`Detector(face_model='img2pose')\` | 89 | 86 | +3.0% |
| \`Detector(face_model='retinaface_r34')\` | 17 | 15 | **+16%** |
| \`MPDetector(face_model='retinaface')\` | 25 | 18 | **+35%** |

img2pose barely moves because the model forward dominates wall time; \`retinaface_r34\` and \`MPDetector\` see bigger wins because their model forwards are smaller relative to the per-batch DataFrame overhead. MPDetector wins biggest because of its 1434 landmark columns — the \`Fex.__init__\` loop scales with column count.

## Why not switch to polars

Considered. Skipped because:

1. \`Fex\` IS a \`pd.DataFrame\` subclass; migrating breaks every user-facing op (\`fex.aus\`, \`fex.iloc[0]\`, \`.extract_*\`, plot integrations).
2. The bottleneck isn't pandas — it's how we're calling it. Polars would still do per-batch construction, just 1.5–2× faster. **Skipping the work entirely (this PR) is 30× on the construction step.**
3. Researcher userbase is pandas-fluent. Polars syntax break for ~2× speedup on operations that aren't the bottleneck is a bad trade.

## Test plan

- [x] Full unit suite: 142 passed, 1 skipped (no regressions)
- [x] \`save=path\` CSV streaming branch verified end-to-end
- [x] \`MPDetector(face_model='retinaface')\` returns sensible Pitch values on multi_face.jpg (~4° on forward-facing portraits, same as before refactor)
- [x] All three \`face_model\` paths return Fex with the same shape and contents as before

## Follow-up (not in this PR)

The root cause is \`data.py:435\`'s manual metadata-propagation loop. pandas has \`_metadata\` machinery that handles this automatically; the manual loop predates that. A separate PR could remove the loop entirely and benefit every Fex construction (not just the per-batch ones) — but it touches FexSeries semantics and warrants its own scope.