### PR TITLE
perf: fold padding/scale inversion into forward() (architectural cleanup)

### DIFF
--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -67,6 +67,8 @@ If you compared `Pitch / Roll / Yaw / X / Y / Z` outputs from `MPDetector` betwe
 
 **Note on intermediate v0.7-dev builds:** a Y/Z-axis convention bug introduced alongside the new alignment (the canonical face model uses head-centric `Y up, Z out`; MediaPipe Face Mesh outputs `Y down, Z into screen`) made `Pitch` cluster at ±π for forward-facing portraits. Fixed in PR #279 before the 0.7.0 release. Only releases at or after this fix produce correct head pose; earlier 0.7-dev snapshots should be re-run.
 
+**Pose translation columns now in original-frame pixels.** The Umeyama alignment that recovers head pose is scale-invariant for rotation (`Pitch/Roll/Yaw` unchanged), but the translation term (`X/Y/Z` columns of the 6DoF pose) moves with the input scale. As of the perf refactor that folds DataLoader Rescale-inversion into `forward()` (replacing the post-hoc `invert_padding_to_results` step), `MPDetector` reads landmarks from the Fex in *original-frame* pixel coords rather than padded-frame coords. So `X/Y/Z` magnitudes in `Fex.facepose` are now in the same coordinate system as `FaceRectX`, `x_0`, etc. — typically smaller than before and shifted, but in a more useful frame. Only relevant if you compared 6DoF translation values across v0.7-dev snapshots.
+
 `MPDetector` also now emits `gaze_pitch` and `gaze_yaw` columns (radians, head-centric frame) in addition to the existing `gaze_angle`. The `gaze_angle` column is preserved for backward compatibility but its semantic shifted from "angle from camera-forward" to "angle from head-forward in head frame" - so a turned head no longer registers as averted gaze even when the eyes are looking along the head's forward axis.
 
 # 0.6.1

--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -62,6 +62,7 @@ from feat.utils.image_operations import (
     convert_bbox_output,
     compute_original_image_size,
     invert_padding_to_results,
+    per_face_padding_inversion_terms,
 )
 from feat.utils.io import get_resource_path
 from feat.utils.mp_plotting import FaceLandmarksConnections
@@ -608,20 +609,41 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
         return batch_results
 
     @torch.inference_mode()
-    def forward(self, faces_data):
+    def forward(self, faces_data, batch_data):
         """
         Run Model Inference on detected faces.
 
         Args:
             faces_data (list of dict): Detected faces and associated data from `detect_faces`.
+            batch_data (dict): The DataLoader's batch dict for this call.
+                Used to convert per-face bbox/landmark coordinates from
+                the padded-image space the models operate in back to the
+                original-frame space the caller expects, in a single
+                vectorized tensor op (replacing the prior post-hoc
+                `invert_padding_to_results` DataFrame mutation).
 
         Returns:
-            Fex: Prediction results dataframe
+            Fex: Per-face prediction results in original-frame
+            coordinates, including FrameHeight / FrameWidth columns.
         """
 
         extracted_faces = torch.cat([face["faces"] for face in faces_data], dim=0)
         new_bboxes = torch.cat([face["new_boxes"] for face in faces_data], dim=0)
         n_faces = extracted_faces.shape[0]
+
+        # Per-face mapping back to the source frame in the batch. Used
+        # below to broadcast the DataLoader's per-frame Rescale
+        # (Padding + Scale) parameters to per-face tensors so we can
+        # convert bboxes / landmarks from padded-image space to
+        # original-frame space without a post-hoc DataFrame walk.
+        n_per_frame = [face["faces"].shape[0] for face in faces_data]
+        frame_idx = torch.repeat_interleave(
+            torch.arange(len(faces_data), device=self.device),
+            torch.tensor(n_per_frame, device=self.device),
+        )
+        pad_left, pad_top, scale, frame_h, frame_w = per_face_padding_inversion_terms(
+            batch_data, frame_idx, self.device
+        )
 
         # Hoist CPU->device transfers out of per-detector branches: landmark
         # and identity detectors both consume the face crops, and previously
@@ -696,7 +718,11 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
         else:
             aus = torch.full((n_faces, 52), float("nan"))
 
-        # Create Fex Output Representation
+        # Create Fex Output Representation. Bboxes come out of
+        # convert_bbox_output in PADDED-frame space (the same space the
+        # face detector + landmark detector operated in). Subtract the
+        # DataLoader's per-face padding and divide by its scale to land
+        # in ORIGINAL-frame space — what the user expects in Fex.
         bboxes = torch.cat(
             [
                 convert_bbox_output(
@@ -707,8 +733,13 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             ],
             dim=0,
         )
+        bboxes_orig = bboxes.clone()
+        bboxes_orig[:, 0] = (bboxes[:, 0] - pad_left) / scale
+        bboxes_orig[:, 1] = (bboxes[:, 1] - pad_top) / scale
+        bboxes_orig[:, 2] = bboxes[:, 2] / scale
+        bboxes_orig[:, 3] = bboxes[:, 3] / scale
         feat_faceboxes = pd.DataFrame(
-            bboxes.cpu().detach().numpy(),
+            bboxes_orig.cpu().detach().numpy(),
             columns=FEAT_FACEBOX_COLUMNS,
         )
 
@@ -718,8 +749,19 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             poses.cpu().detach().numpy(), columns=FEAT_FACEPOSE_COLUMNS_6D
         )
 
+        # Invert the DataLoader's Rescale on the 478 (x, y, z) landmark
+        # triples. Z is depth in face-crop scale already (untouched by
+        # the image-plane Rescale), so only X/Y need adjustment.
+        landmarks_3d_padded = new_landmarks.reshape(n_faces, 478, 3)
+        landmarks_3d_orig = landmarks_3d_padded.clone()
+        landmarks_3d_orig[..., 0] = (
+            landmarks_3d_padded[..., 0] - pad_left[:, None]
+        ) / scale[:, None]
+        landmarks_3d_orig[..., 1] = (
+            landmarks_3d_padded[..., 1] - pad_top[:, None]
+        ) / scale[:, None]
         feat_landmarks = pd.DataFrame(
-            new_landmarks.reshape(n_faces, 478 * 3).cpu().detach().numpy(),
+            landmarks_3d_orig.reshape(n_faces, 478 * 3).cpu().detach().numpy(),
             columns=MP_LANDMARK_COLUMNS,
         )
         feat_aus = pd.DataFrame(aus.cpu().detach().numpy(), columns=MP_BLENDSHAPE_NAMES)
@@ -732,6 +774,17 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
+        # Frame metadata: original (pre-Rescale) frame dimensions per
+        # face. Added here instead of in `invert_padding_to_results`
+        # post-hoc so the entire DataFrame leaves forward() in
+        # original-frame coords with no further mutation.
+        feat_frame_meta = pd.DataFrame(
+            {
+                "FrameHeight": frame_h.cpu().detach().numpy().astype(np.float64),
+                "FrameWidth": frame_w.cpu().detach().numpy().astype(np.float64),
+            }
+        )
+
         return Fex(
             pd.concat(
                 [
@@ -741,6 +794,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                     feat_aus,
                     feat_emotions,
                     feat_identities,
+                    feat_frame_meta,
                 ],
                 axis=1,
             ),
@@ -837,7 +891,7 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
                 face_size=self.face_size,
                 face_detection_threshold=face_detection_threshold,
             )
-            batch_results = self.forward(faces_data)
+            batch_results = self.forward(faces_data, batch_data)
 
             # Create metadata for each frame
             file_names = []
@@ -853,8 +907,10 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             batch_results["input"] = np.concatenate(file_names)
             batch_results["frame"] = np.concatenate(frame_ids)
 
-            # Invert the face boxes and landmarks based on the padded output size.
-            invert_padding_to_results(batch_results, batch_data, n_landmarks=478)
+            # Padded->original-frame coordinate inversion now happens
+            # inside forward() in tensor space; no post-hoc DataFrame walk
+            # is needed here. (`invert_padding_to_results` is still
+            # exported for any external caller that depended on it.)
 
             batch_output.append(batch_results)
             # Use the actual batch size (may be smaller than `batch_size` for the

--- a/feat/MPDetector.py
+++ b/feat/MPDetector.py
@@ -733,13 +733,16 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
             ],
             dim=0,
         )
-        bboxes_orig = bboxes.clone()
-        bboxes_orig[:, 0] = (bboxes[:, 0] - pad_left) / scale
-        bboxes_orig[:, 1] = (bboxes[:, 1] - pad_top) / scale
-        bboxes_orig[:, 2] = bboxes[:, 2] / scale
-        bboxes_orig[:, 3] = bboxes[:, 3] / scale
+        # In-place arithmetic: each axis reads + writes the same column,
+        # axes are independent, and `bboxes` is freshly allocated by
+        # torch.cat above and not referenced again after the DataFrame
+        # is built. (Score column 4 is unchanged by Rescale inversion.)
+        bboxes[:, 0] = (bboxes[:, 0] - pad_left) / scale
+        bboxes[:, 1] = (bboxes[:, 1] - pad_top) / scale
+        bboxes[:, 2] = bboxes[:, 2] / scale
+        bboxes[:, 3] = bboxes[:, 3] / scale
         feat_faceboxes = pd.DataFrame(
-            bboxes_orig.cpu().detach().numpy(),
+            bboxes.cpu().detach().numpy(),
             columns=FEAT_FACEBOX_COLUMNS,
         )
 
@@ -752,16 +755,17 @@ class MPDetector(nn.Module, PyTorchModelHubMixin):
         # Invert the DataLoader's Rescale on the 478 (x, y, z) landmark
         # triples. Z is depth in face-crop scale already (untouched by
         # the image-plane Rescale), so only X/Y need adjustment.
-        landmarks_3d_padded = new_landmarks.reshape(n_faces, 478, 3)
-        landmarks_3d_orig = landmarks_3d_padded.clone()
-        landmarks_3d_orig[..., 0] = (
-            landmarks_3d_padded[..., 0] - pad_left[:, None]
+        # In-place is safe — `new_landmarks` is not used after the
+        # DataFrame is built.
+        landmarks_3d = new_landmarks.reshape(n_faces, 478, 3)
+        landmarks_3d[..., 0] = (
+            landmarks_3d[..., 0] - pad_left[:, None]
         ) / scale[:, None]
-        landmarks_3d_orig[..., 1] = (
-            landmarks_3d_padded[..., 1] - pad_top[:, None]
+        landmarks_3d[..., 1] = (
+            landmarks_3d[..., 1] - pad_top[:, None]
         ) / scale[:, None]
         feat_landmarks = pd.DataFrame(
-            landmarks_3d_orig.reshape(n_faces, 478 * 3).cpu().detach().numpy(),
+            landmarks_3d.reshape(n_faces, 478 * 3).cpu().detach().numpy(),
             columns=MP_LANDMARK_COLUMNS,
         )
         feat_aus = pd.DataFrame(aus.cpu().detach().numpy(), columns=MP_BLENDSHAPE_NAMES)

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -38,6 +38,7 @@ from feat.utils.image_operations import (
     convert_bbox_output,
     compute_original_image_size,
     invert_padding_to_results,
+    per_face_padding_inversion_terms,
 )
 from feat.data import Fex, ImageDataset, TensorDataset, VideoDataset
 from skops.io import load, get_untrusted_types
@@ -517,20 +518,42 @@ class Detector(nn.Module, PyTorchModelHubMixin):
         return batch_results
 
     @torch.inference_mode()
-    def forward(self, faces_data):
+    def forward(self, faces_data, batch_data):
         """
         Run Model Inference on detected faces.
 
         Args:
             faces_data (list of dict): Detected faces and associated data from `detect_faces`.
+            batch_data (dict): The DataLoader's batch dict for this call.
+                Used to convert per-face bbox/landmark coordinates from the
+                padded-image space the models operate in back to the
+                original-frame space the caller expects, in a single
+                vectorized tensor op (replacing the prior post-hoc
+                `invert_padding_to_results` DataFrame mutation).
 
         Returns:
-            Fex: Prediction results dataframe
+            pandas.DataFrame: Per-face prediction results in original-frame
+            coordinates, including FrameHeight / FrameWidth columns.
+            Wrapped into a Fex by `detect()` once at the end.
         """
 
         extracted_faces = torch.cat([face["faces"] for face in faces_data], dim=0)
         new_bboxes = torch.cat([face["new_boxes"] for face in faces_data], dim=0)
         n_faces = extracted_faces.shape[0]
+
+        # Per-face mapping back to the source frame in the batch. Used
+        # below to broadcast the DataLoader's per-frame Rescale
+        # (Padding + Scale) parameters to per-face tensors so we can
+        # convert bboxes / landmarks from padded-image space to
+        # original-frame space without a post-hoc DataFrame walk.
+        n_per_frame = [face["faces"].shape[0] for face in faces_data]
+        frame_idx = torch.repeat_interleave(
+            torch.arange(len(faces_data), device=self.device),
+            torch.tensor(n_per_frame, device=self.device),
+        )
+        pad_left, pad_top, scale, frame_h, frame_w = per_face_padding_inversion_terms(
+            batch_data, frame_idx, self.device
+        )
 
         # Hoist CPU->device transfers out of per-detector branches: landmark
         # and identity detectors both consume the face crops, and previously
@@ -590,7 +613,11 @@ class Detector(nn.Module, PyTorchModelHubMixin):
         else:
             aus = torch.full((n_faces, 20), float("nan"))
 
-        # Create Fex Output Representation
+        # Create Fex Output Representation. Bboxes come out of
+        # convert_bbox_output in PADDED-frame space (the same space the
+        # face detector + landmark detector operated in). Subtract the
+        # DataLoader's per-face padding and divide by its scale to land
+        # in ORIGINAL-frame space — what the user expects in Fex.
         bboxes = torch.cat(
             [
                 convert_bbox_output(
@@ -601,8 +628,13 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             ],
             dim=0,
         )
+        bboxes_orig = bboxes.clone()
+        bboxes_orig[:, 0] = (bboxes[:, 0] - pad_left) / scale
+        bboxes_orig[:, 1] = (bboxes[:, 1] - pad_top) / scale
+        bboxes_orig[:, 2] = bboxes[:, 2] / scale
+        bboxes_orig[:, 3] = bboxes[:, 3] / scale
         feat_faceboxes = pd.DataFrame(
-            bboxes.cpu().detach().numpy(),
+            bboxes_orig.cpu().detach().numpy(),
             columns=FEAT_FACEBOX_COLUMNS,
         )
 
@@ -640,9 +672,21 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             poses.cpu().detach().numpy(), columns=FEAT_FACEPOSE_COLUMNS_6D
         )
 
+        # Invert the DataLoader's Rescale on the 68 (x, y) landmark pairs.
+        # The PnP block above (when active) already consumed the
+        # padded-frame landmarks; invert here for the user-visible
+        # output. NaN landmarks (no-detection rows) propagate as NaN
+        # through the arithmetic, which is what we want.
         reshape_landmarks = new_landmarks.reshape(new_landmarks.shape[0], 68, 2)
+        reshape_landmarks_orig = reshape_landmarks.clone()
+        reshape_landmarks_orig[..., 0] = (
+            reshape_landmarks[..., 0] - pad_left[:, None]
+        ) / scale[:, None]
+        reshape_landmarks_orig[..., 1] = (
+            reshape_landmarks[..., 1] - pad_top[:, None]
+        ) / scale[:, None]
         reordered_landmarks = torch.cat(
-            [reshape_landmarks[:, :, 0], reshape_landmarks[:, :, 1]], dim=1
+            [reshape_landmarks_orig[:, :, 0], reshape_landmarks_orig[:, :, 1]], dim=1
         )
         feat_landmarks = pd.DataFrame(
             reordered_landmarks.cpu().detach().numpy(),
@@ -659,6 +703,17 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             identity_embeddings.cpu().detach().numpy(), columns=FEAT_IDENTITY_COLUMNS[1:]
         )
 
+        # Frame metadata: original (pre-Rescale) frame dimensions per
+        # face. Added here instead of in `invert_padding_to_results`
+        # post-hoc so the entire DataFrame leaves forward() in
+        # original-frame coords with no further mutation.
+        feat_frame_meta = pd.DataFrame(
+            {
+                "FrameHeight": frame_h.cpu().detach().numpy().astype(np.float64),
+                "FrameWidth": frame_w.cpu().detach().numpy().astype(np.float64),
+            }
+        )
+
         return Fex(
             pd.concat(
                 [
@@ -668,6 +723,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                     feat_aus,
                     feat_emotions,
                     feat_identities,
+                    feat_frame_meta,
                 ],
                 axis=1,
             ),
@@ -777,7 +833,7 @@ class Detector(nn.Module, PyTorchModelHubMixin):
                 face_size=self.face_size if hasattr(self, "face_size") else 112,
                 face_detection_threshold=face_detection_threshold,
             )
-            batch_results = self.forward(faces_data)
+            batch_results = self.forward(faces_data, batch_data)
 
             # Create metadata for each frame
             file_names = []
@@ -793,8 +849,10 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             batch_results["input"] = np.concatenate(file_names)
             batch_results["frame"] = np.concatenate(frame_ids)
 
-            # Invert the face boxes and landmarks based on the padded output size.
-            invert_padding_to_results(batch_results, batch_data, n_landmarks=68)
+            # Padded->original-frame coordinate inversion now happens
+            # inside forward() in tensor space; no post-hoc DataFrame walk
+            # is needed here. (`invert_padding_to_results` is still
+            # exported for any external caller that depended on it.)
 
             if save:
                 batch_results.to_csv(save, mode="a", index=False, header=batch_id == 0)

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -628,13 +628,16 @@ class Detector(nn.Module, PyTorchModelHubMixin):
             ],
             dim=0,
         )
-        bboxes_orig = bboxes.clone()
-        bboxes_orig[:, 0] = (bboxes[:, 0] - pad_left) / scale
-        bboxes_orig[:, 1] = (bboxes[:, 1] - pad_top) / scale
-        bboxes_orig[:, 2] = bboxes[:, 2] / scale
-        bboxes_orig[:, 3] = bboxes[:, 3] / scale
+        # In-place arithmetic: each axis reads + writes the same column,
+        # axes are independent, and `bboxes` is freshly allocated by
+        # torch.cat above and not referenced again after the DataFrame
+        # is built. (Score column 4 is unchanged by Rescale inversion.)
+        bboxes[:, 0] = (bboxes[:, 0] - pad_left) / scale
+        bboxes[:, 1] = (bboxes[:, 1] - pad_top) / scale
+        bboxes[:, 2] = bboxes[:, 2] / scale
+        bboxes[:, 3] = bboxes[:, 3] / scale
         feat_faceboxes = pd.DataFrame(
-            bboxes_orig.cpu().detach().numpy(),
+            bboxes.cpu().detach().numpy(),
             columns=FEAT_FACEBOX_COLUMNS,
         )
 
@@ -675,18 +678,18 @@ class Detector(nn.Module, PyTorchModelHubMixin):
         # Invert the DataLoader's Rescale on the 68 (x, y) landmark pairs.
         # The PnP block above (when active) already consumed the
         # padded-frame landmarks; invert here for the user-visible
-        # output. NaN landmarks (no-detection rows) propagate as NaN
-        # through the arithmetic, which is what we want.
+        # output. In-place is safe — `new_landmarks` is not used after
+        # the DataFrame is built. NaN landmarks (no-detection rows)
+        # propagate as NaN through the arithmetic, which is what we want.
         reshape_landmarks = new_landmarks.reshape(new_landmarks.shape[0], 68, 2)
-        reshape_landmarks_orig = reshape_landmarks.clone()
-        reshape_landmarks_orig[..., 0] = (
+        reshape_landmarks[..., 0] = (
             reshape_landmarks[..., 0] - pad_left[:, None]
         ) / scale[:, None]
-        reshape_landmarks_orig[..., 1] = (
+        reshape_landmarks[..., 1] = (
             reshape_landmarks[..., 1] - pad_top[:, None]
         ) / scale[:, None]
         reordered_landmarks = torch.cat(
-            [reshape_landmarks_orig[:, :, 0], reshape_landmarks_orig[:, :, 1]], dim=1
+            [reshape_landmarks[:, :, 0], reshape_landmarks[:, :, 1]], dim=1
         )
         feat_landmarks = pd.DataFrame(
             reordered_landmarks.cpu().detach().numpy(),

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -1359,6 +1359,48 @@ def compute_original_image_size(batch_data):
     return original_height_width
 
 
+def per_face_padding_inversion_terms(batch_data, frame_idx, device):
+    """Look up per-face DataLoader-Rescale inversion terms.
+
+    The DataLoader's ``Rescale`` transform pads + scales each frame to a
+    uniform shape so the batch can collate. ``forward()`` consumes the
+    padded frames directly, so any coordinates it produces (face bboxes,
+    landmarks) are in *padded-frame* space. To convert back to the
+    *original-frame* coordinates the user expects, we need per-frame
+    ``pad_left``, ``pad_top``, ``scale`` values plus the original
+    ``frame_h`` / ``frame_w``.
+
+    This helper expands those per-frame quantities to per-face tensors
+    via the ``frame_idx`` mapping (which face came from which frame in
+    the batch).
+
+    Args:
+        batch_data: dict from the DataLoader. Must contain ``"Padding"``
+            (with ``"Left"`` / ``"Top"``), ``"Scale"``, and ``"Image"``.
+        frame_idx: ``[N]`` long tensor mapping each face to its source
+            frame in the batch. Build via
+            ``torch.repeat_interleave(arange(B), n_faces_per_frame)``.
+        device: device the returned tensors should live on (typically
+            the model's device, so the inversion math runs on-device
+            without an extra round-trip).
+
+    Returns:
+        tuple of five ``[N]`` float tensors on ``device``:
+        ``(pad_left, pad_top, scale, frame_h, frame_w)``.
+    """
+    # Cast to float32 BEFORE moving to device. MPS doesn't accept
+    # float64 tensors via `.to('mps')`, and the DataLoader's Padding /
+    # Scale tensors come back as float64 by default. Casting first
+    # avoids the round-trip.
+    pad_left = batch_data["Padding"]["Left"].float().to(device)[frame_idx]
+    pad_top = batch_data["Padding"]["Top"].float().to(device)[frame_idx]
+    scale = batch_data["Scale"].float().to(device)[frame_idx]
+    original_hw = compute_original_image_size(batch_data).float().to(device)
+    frame_h = original_hw[frame_idx, 0]
+    frame_w = original_hw[frame_idx, 1]
+    return pad_left, pad_top, scale, frame_h, frame_w
+
+
 def invert_padding_to_results(batch_results, batch_data, n_landmarks):
     """Vectorized inversion of dataloader padding/scaling on a batch of detector outputs.
 


### PR DESCRIPTION
## Summary

Detector and MPDetector previously had a "split brain" coordinate pipeline:

```
forward(faces_data) -> DataFrame with bbox/landmark coords in PADDED-image space
detect() -> invert_padding_to_results(...) mutates DataFrame in place
            to convert to ORIGINAL-frame space
```

That post-hoc mutation step did the same arithmetic — `(coord - pad_xy) / scale` — through pandas, with an iloc-based 2D column write. Even after PR #283's iloc speedup, the per-batch `invert_padding` cost was ~0.4 s on a 472-frame video (5-6 % of total).

This PR folds the inversion into `forward()` in tensor space, before the DataFrame is built. The DataFrame leaves `forward()` already in original-frame coords; `detect()` no longer mutates it post-hoc.

## Stacked PR

This branches off `perf/v0.7-remove-redundant-metadata-loop` (PR #283). Should land **after** #283 merges — the change builds on #283's batched-extract + iloc work.

## What changes

**New helper** `per_face_padding_inversion_terms` in `image_operations.py`:
```python
pad_left, pad_top, scale, frame_h, frame_w = per_face_padding_inversion_terms(
    batch_data, frame_idx, device
)
```
Turns the DataLoader's per-frame Rescale params into per-face tensors via a `frame_idx` broadcast. Cheap, on-device.

**`Detector.forward(faces_data, batch_data)`** and **`MPDetector.forward(faces_data, batch_data)`** now apply inversion to the bbox and landmark tensors in tensor-space, before DataFrame construction. PnP in Detector still runs on padded-frame landmarks (so PnP intrinsics match); inversion happens after.

**`FrameHeight` / `FrameWidth` columns** are appended to `forward()`'s output DataFrame as a small `feat_frame_meta` block in the `pd.concat`. Same columns in the final Fex as before.

**`detect()` in both classes** drops the `invert_padding_to_results(...)` call. The function remains exported from `feat.utils.image_operations` for any external caller; only the internal use is gone.

## Why this matters beyond perf

1. **One coordinate space throughout the public pipeline.** Previously `FaceRectX` / `x_0` / etc. meant different things at different points — padded-frame inside `forward()`, original-frame in the user's hand. Now: original-frame from the moment the DataFrame is created.
2. **Inversion math lives next to the bbox/landmark tensor.** Today it's in a 700-line-distant utility. After: inline in `forward()`, next to the tensor that needs inverting.
3. **Eliminates a per-batch mutation step.** Removes the bug class where `invert_padding_to_results` could be called twice and silently corrupt data.
4. **Easier to add new output coordinate spaces** (e.g., normalized [0,1], head-centric). Today you'd modify the post-hoc mutator; after, you add a tensor op next to the existing one.

## Subtle dtype fix

Cast to `float32` **before** moving to device. The DataLoader's `Padding`/`Scale` tensors come back as `float64`, and MPS doesn't accept `.to('mps')` on `float64`. Fixed via `.float().to(device)` instead of `.to(device).float()`.

## Test plan

- [x] Detector retinaface_r34 + svm AU on `multi_face.jpg` — same `FaceRectX`, same `x_0`, `FrameHeight=667` (correct for 1000×667 image).
- [x] Detector img2pose — still works (PnP path preserved).
- [x] MPDetector retinaface — same `x_0=[728.5778, 571.3271, 369.3371]`.
- [x] MPDetector pose values via Umeyama alignment unchanged (scale-invariant).
- [x] Detector with `no_face.mp4` — NaN bboxes propagate correctly through tensor arithmetic.
- [x] `pytest feat/tests/test_mpdetector_retinaface.py` — 3 pose tests pass.
- [x] `pytest feat/tests/test_invert_padding_to_results.py feat/tests/test_image_ops.py feat/tests/test_data.py` — 35 tests pass (back-compat function still works for direct callers).
- [x] Long-video benchmark on M5 MBP MPS, 472 frames, batch 16: throughput within noise of #283 baseline (the perf win is small — the architectural cleanup is the real win).

## Follow-up

`invert_padding_to_results` could be deprecated for v0.8 (warn on import, remove the function in v0.9) once external use is confirmed minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)