### PR TITLE
fix: OMP_NUM_THREADS=1 default to avoid xgboost+torch segfault on Python 3.13

### DIFF
--- a/feat/__init__.py
+++ b/feat/__init__.py
@@ -4,10 +4,52 @@
 
 from __future__ import absolute_import
 
+# --- OpenMP runtime conflict mitigation (must run before any other import) ---
+#
+# torch and xgboost both link against OpenMP, but PyPI wheels of each link
+# against DIFFERENT libomp/libiomp5 dylibs on macOS. When both runtimes
+# initialize independently in the same process, their thread-pool TLS state
+# diverges and one of them later segfaults inside `__kmp_*` routines.
+# Symptom on the affected configs: SIGSEGV (exit 139) during the FIRST op
+# from whichever runtime initialized second.
+#
+# Forcing OMP_NUM_THREADS=1 at process start makes both runtimes use a
+# single thread, which sidesteps the divergent thread-pool state and is
+# the workaround documented in:
+#   https://github.com/dmlc/xgboost/issues/11500
+#   https://github.com/pytorch/pytorch/issues/44282
+#   https://github.com/microsoft/LightGBM/issues/6595
+#
+# Performance impact is minor for typical py-feat use cases:
+# - xgboost AU classifiers are small (n_estimators=100, depth=3), so
+#   single-threaded scoring is essentially as fast as multi-threaded.
+# - torch's heavy inference runs on MPS / CUDA / CPU-BLAS, which Apple's
+#   Accelerate or MKL parallelize independently of OMP_NUM_THREADS.
+# - numpy via OpenBLAS does respect OMP_NUM_THREADS, so dot products run
+#   single-threaded.
+# Users who need multi-threaded OMP can set OMP_NUM_THREADS=N in their
+# environment BEFORE importing feat; this block only sets a default when
+# the variable is unset.
+#
+# `KMP_DUPLICATE_LIB_OK=TRUE` was a tempting alternative but PyTorch
+# explicitly warns it "may cause crashes or silently produce incorrect
+# results" (#44282) — it suppresses the startup check without fixing the
+# underlying divergent state. Don't use it.
+import os as _os
+
+if "OMP_NUM_THREADS" not in _os.environ:
+    _os.environ["OMP_NUM_THREADS"] = "1"
+
+# Import xgboost early too as defense in depth so its runtime
+# (and the libomp it links against) is loaded before any torch-using
+# import. With OMP_NUM_THREADS=1 above this is belt-and-braces, but
+# cheap and harmless.
+import xgboost  # noqa: F401, E402
+
 __author__ = """Jin Hyun Cheong, Tiankang Xie, Sophie Byrne, Eshin Jolly, Luke Chang """
 __email__ = "jcheong0428@gmail.com, eshin.jolly@gmail.com, luke.j.chang@dartmouth.edu"
 __all__ = ["detector", "data", "utils", "plotting", "transforms", "__version__"]
 
-from .data import Fex  # noqa: F401
-from .detector import Detector  # noqa: F401
-from .version import __version__
+from .data import Fex  # noqa: F401, E402
+from .detector import Detector  # noqa: F401, E402
+from .version import __version__  # noqa: E402

--- a/feat/detector.py
+++ b/feat/detector.py
@@ -1,3 +1,13 @@
+# Import xgboost FIRST, before any module that pulls in torch. On
+# Python 3.13 + macOS, if torch's OpenMP/MKL runtime loads before
+# xgboost's, subsequent xgboost.Booster.__setstate__ calls during
+# skops.io.load(...) crash the process with SIGSEGV. The first OpenMP
+# runtime wins; loading xgboost first puts its runtime in charge and
+# the skops load path stays stable. Verified empirically: with this
+# order the load succeeds, with `import torch` ahead of it the load
+# is exit 139.
+import xgboost  # noqa: F401  (must come before torch-using imports)
+
 import os
 import json
 from tqdm import tqdm


### PR DESCRIPTION
## Summary

Release-blocker for v0.7.0 on Python 3.13 + macOS. `Detector(au_model='xgb')` (the default) currently crashes with **SIGSEGV (exit 139)** before this fix.

## Root cause

A well-known OpenMP runtime conflict, **not** a py-feat bug:

- PyPI wheels of `torch` and `xgboost` link against DIFFERENT `libomp` / `libiomp5` dylibs.
- Both get `dlopen`'d at different addresses in the same process.
- Their thread-pool TLS state diverges.
- One runtime crashes inside `__kmp_*` routines during the first op after the other initializes.

Upstream issues:
- [dmlc/xgboost#11500](https://github.com/dmlc/xgboost/issues/11500) — *"xgboost loads `libomp` from homebrew first while then torch loads its own version"*
- [pytorch/pytorch#44282](https://github.com/pytorch/pytorch/issues/44282) — *"PyTorch wheel's own OpenMP library clashing with system-wide OpenMP"* (open since 2020)
- [pytorch/pytorch#161865](https://github.com/pytorch/pytorch/issues/161865) — recent M4 SIGSEGV in libomp.dylib
- [microsoft/LightGBM#6595](https://github.com/microsoft/LightGBM/issues/6595) — same conflict, lightgbm flavor
- [huggingface/transformers#33789](https://github.com/huggingface/transformers/issues/33789) — same conflict, transformers flavor

## Fix

Set **`OMP_NUM_THREADS=1`** at the very top of `feat/__init__.py`, only if the user hasn't already set it. Forces both runtimes to single-thread mode, sidestepping the divergent thread-pool state. This is the workaround documented in xgboost #11500 + pytorch #44282.

Also `import xgboost` early in `feat/__init__.py` and `feat/detector.py` as defense in depth.

`KMP_DUPLICATE_LIB_OK=TRUE` was the obvious-tempting alternative but **doesn't fix our segfault** (only suppresses the startup check without addressing the divergent state). PyTorch explicitly warns against it (#44282).

## Performance impact

Minor. The big workloads in py-feat (model inference) run on MPS / CUDA / Apple Accelerate / MKL — those parallelize independently of `OMP_NUM_THREADS`. xgboost AU classifiers are small enough that single-threaded scoring is essentially as fast as multi-threaded. Numpy/OpenBLAS direct calls do go single-threaded, but those are rare in the FEAT pipeline.

Users who need multi-threaded OpenMP can opt in by setting `OMP_NUM_THREADS=N` in their environment **before** importing feat.

## Test plan

- [x] `Detector(au_model='xgb').detect(multi_face.jpg)` — 5 faces, valid AU01 values, instantiates in 0.7s (was: SIGSEGV)
- [x] User-set `OMP_NUM_THREADS=4` is respected (not overridden)
- [x] Unset `OMP_NUM_THREADS` defaults to `'1'` after `import feat`
- [x] 85 targeted tests pass (image_ops + invert_padding + data + stats + video_dataset + arcface + retinaface_r34 + mpdetector_retinaface)
- [x] Empirical bisection confirms the conflict: `import torch + torch.inference + Detector(xgb)` SIGSEGV's without the fix; same code with the fix succeeds

## Why not change Detector's default `au_model`

`Detector(au_model='xgb')` has been the documented default since v0.5 and is what most users get. Falling back to `'svm'` would be a silent quality regression. The OMP fix is a cleaner mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)