### PR TITLE
feat: BS→AU PLS regressor (Cheong-style, 10K CelebV-HQ)

### DIFF
--- a/feat/tests/test_blendshape_to_au.py
+++ b/feat/tests/test_blendshape_to_au.py
@@ -1,0 +1,205 @@
+"""Tests for ``feat.utils.blendshape_to_au``.
+
+Covers the BS→AU PLS regressor (``pls_predict_batch``) and the dlib-68 ↔
+MediaPipe-478 index map (``DLIB68_FROM_MP478`` / ``mp478_row_to_dlib68_view``).
+
+The PLS-loader tests do an actual HuggingFace Hub fetch on first run; subsequent
+runs hit the local cache so they don't require network. Tests that exercise
+shape contracts use a stub of the lazy-loaded weights so they don't even need
+the cached file to be present.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from feat.utils import blendshape_to_au as b2a
+
+
+# ---------------------------------------------------------------------
+# Helpers — module-level stub for the PLS weights so most tests don't
+# need the real file. Callers that want the real weights use ``hf_load``.
+# ---------------------------------------------------------------------
+
+@pytest.fixture
+def stub_pls_weights(monkeypatch):
+    """Replace the lazy weight loader with deterministic stub weights.
+
+    52 → 20 linear map: ``coef[i, j] = 1`` if the j-th AU pulls from the i-th
+    blendshape, else 0. Intercept is zeros. Lets shape / clip / 1-D-handling
+    tests run offline.
+    """
+    rng = np.random.default_rng(0)
+    coef = rng.standard_normal((52, 20)).astype(np.float32) * 0.1
+    intercept = rng.standard_normal(20).astype(np.float32) * 0.05
+    bs_cols = ["_neutral"] + [f"bs_{i}" for i in range(51)]
+    au_cols = [
+        "AU01", "AU02", "AU04", "AU05", "AU06", "AU07", "AU09", "AU10",
+        "AU11", "AU12", "AU14", "AU15", "AU17", "AU20", "AU23", "AU24",
+        "AU25", "AU26", "AU28", "AU43",
+    ]
+    monkeypatch.setattr(
+        b2a, "_PLS_WEIGHTS", {
+            "coef": coef,
+            "intercept": intercept,
+            "blendshape_columns": bs_cols,
+            "au_columns": au_cols,
+        },
+    )
+    return coef, intercept
+
+
+# ---------------------------------------------------------------------
+# pls_predict_batch
+# ---------------------------------------------------------------------
+
+class TestPlsPredictBatch:
+    def test_2d_batch_shape(self, stub_pls_weights):
+        x = np.zeros((4, 52), dtype=np.float32)
+        out = b2a.pls_predict_batch(x)
+        assert out.shape == (4, 20)
+        assert out.dtype == np.float32
+
+    def test_1d_input_returns_1d_output(self, stub_pls_weights):
+        """Single-vector input should return a single-vector output (no leading axis)."""
+        x = np.zeros(52, dtype=np.float32)
+        out = b2a.pls_predict_batch(x)
+        assert out.shape == (20,), f"expected (20,), got {out.shape}"
+
+    def test_1d_and_2d_agree(self, stub_pls_weights):
+        """``predict(v)`` and ``predict(v[None])[0]`` should match."""
+        rng = np.random.default_rng(42)
+        v = rng.uniform(0, 1, size=52).astype(np.float32)
+        out_1d = b2a.pls_predict_batch(v, clip=False)
+        out_2d = b2a.pls_predict_batch(v[None, :], clip=False)
+        np.testing.assert_allclose(out_1d, out_2d[0], atol=1e-6)
+
+    def test_clip_default_in_unit_interval(self, stub_pls_weights):
+        rng = np.random.default_rng(1)
+        # Use blendshape values >> 1 so the linear projection definitely
+        # produces some out-of-[0,1] outputs without clipping.
+        x = rng.uniform(0, 5, size=(8, 52)).astype(np.float32)
+        out = b2a.pls_predict_batch(x, clip=True)
+        assert out.min() >= 0.0
+        assert out.max() <= 1.0
+
+    def test_clip_off_can_exceed_unit_interval(self, stub_pls_weights):
+        rng = np.random.default_rng(1)
+        x = rng.uniform(0, 5, size=(8, 52)).astype(np.float32)
+        out_unclipped = b2a.pls_predict_batch(x, clip=False)
+        # With random ±0.1-magnitude coef and inputs up to 5, expect SOME
+        # output to escape [0, 1]; assert at least one boundary is breached.
+        assert (out_unclipped < 0.0).any() or (out_unclipped > 1.0).any()
+
+    def test_wrong_1d_length_raises(self, stub_pls_weights):
+        with pytest.raises(ValueError, match=r"1-D input of length 52"):
+            b2a.pls_predict_batch(np.zeros(50, dtype=np.float32))
+
+    def test_wrong_2d_columns_raises(self, stub_pls_weights):
+        with pytest.raises(ValueError, match=r"2-D input with 52 columns"):
+            b2a.pls_predict_batch(np.zeros((4, 51), dtype=np.float32))
+
+    def test_3d_input_raises(self, stub_pls_weights):
+        with pytest.raises(ValueError, match=r"must be 1-D"):
+            b2a.pls_predict_batch(np.zeros((2, 4, 52), dtype=np.float32))
+
+    def test_dtype_promotion_is_safe(self, stub_pls_weights):
+        """float64 / int input shouldn't blow up — internally promoted to float32."""
+        x_f64 = np.zeros((2, 52), dtype=np.float64)
+        out_f64 = b2a.pls_predict_batch(x_f64)
+        x_int = np.zeros((2, 52), dtype=np.int32)
+        out_int = b2a.pls_predict_batch(x_int)
+        np.testing.assert_allclose(out_f64, out_int, atol=1e-6)
+
+
+# ---------------------------------------------------------------------
+# DLIB68_FROM_MP478 + mp478_row_to_dlib68_view
+# ---------------------------------------------------------------------
+
+class TestDlib68FromMp478:
+    def test_length_is_68(self):
+        assert len(b2a.DLIB68_FROM_MP478) == 68
+
+    def test_indices_in_mp_range(self):
+        for idx in b2a.DLIB68_FROM_MP478:
+            assert 0 <= idx < 478, f"MP index out of range: {idx}"
+
+    def test_no_duplicate_indices(self):
+        # Each dlib slot should map to a unique MP vertex.
+        assert len(set(b2a.DLIB68_FROM_MP478)) == 68
+
+
+class TestMp478RowToDlib68View:
+    def test_returns_dlib68_xy_keys(self):
+        # Build a synthetic MP-478 row where x_i = i and y_i = i + 1000.
+        # Then view["x_d"] should equal DLIB68_FROM_MP478[d] (the MP index).
+        row = pd.Series({
+            **{f"x_{i}": float(i) for i in range(478)},
+            **{f"y_{i}": float(i + 1000) for i in range(478)},
+        })
+        view = b2a.mp478_row_to_dlib68_view(row)
+        for dlib_idx in range(68):
+            mp_idx = b2a.DLIB68_FROM_MP478[dlib_idx]
+            assert view[f"x_{dlib_idx}"] == float(mp_idx)
+            assert view[f"y_{dlib_idx}"] == float(mp_idx + 1000)
+        # Sanity: dlib chin tip is index 8 in the list, which maps to MP 176;
+        # dlib idx 10 (center of jaw) maps to MP 152 per the table.
+        assert view["x_10"] == 152.0
+        assert view["y_10"] == 1152.0
+
+    def test_passes_through_optional_metadata(self):
+        row = pd.Series({
+            **{f"x_{i}": float(i) for i in range(478)},
+            **{f"y_{i}": float(i) for i in range(478)},
+            "FaceRectX": 100.0,
+            "Pitch": 0.1,
+            "Yaw": -0.2,
+            "Roll": 0.05,
+        })
+        view = b2a.mp478_row_to_dlib68_view(row)
+        assert view["FaceRectX"] == 100.0
+        assert view["Pitch"] == 0.1
+        assert view["Yaw"] == -0.2
+        assert view["Roll"] == 0.05
+
+    def test_missing_keys_return_nan(self):
+        # Row missing some MP indices — the `.get(...)` fallback should yield NaN
+        # without raising
+        row = {f"x_{i}": float(i) for i in range(100)}  # only first 100
+        row.update({f"y_{i}": float(i) for i in range(100)})
+        view = b2a.mp478_row_to_dlib68_view(row)
+        # dlib idx 8 maps to MP 152 which is missing → NaN
+        assert np.isnan(view["x_8"])
+        assert np.isnan(view["y_8"])
+
+
+# ---------------------------------------------------------------------
+# Real HF Hub fetch — runs once, then hits cache. Marked with `network`
+# so it can be deselected with `pytest -m 'not network'` in offline CI.
+# ---------------------------------------------------------------------
+
+@pytest.mark.network
+class TestRealPlsLoad:
+    def test_load_real_weights_and_predict(self):
+        # Force a fresh module load by clearing the cached weights
+        b2a._PLS_WEIGHTS = None
+        weights = b2a._load_pls_weights()
+        assert weights["coef"].shape == (52, 20)
+        assert weights["intercept"].shape == (20,)
+        assert len(weights["blendshape_columns"]) == 52
+        assert len(weights["au_columns"]) == 20
+        assert "AU12" in weights["au_columns"]
+
+        # Sanity: predict on a known blendshape vector. mouthSmileLeft+Right
+        # should produce non-trivial AU12 (lip corner pull).
+        bs_cols = weights["blendshape_columns"]
+        x = np.zeros(52, dtype=np.float32)
+        if "mouthSmileLeft" in bs_cols and "mouthSmileRight" in bs_cols:
+            x[bs_cols.index("mouthSmileLeft")] = 1.0
+            x[bs_cols.index("mouthSmileRight")] = 1.0
+        au = b2a.pls_predict_batch(x)
+        assert au.shape == (20,)
+        # AU output is clipped to [0, 1]
+        assert au.min() >= 0.0 and au.max() <= 1.0

--- a/feat/utils/blendshape_to_au.py
+++ b/feat/utils/blendshape_to_au.py
@@ -1,0 +1,121 @@
+"""Map MediaPipe / ARKit blendshapes to FACS Action Unit intensities.
+
+Provides a learned PLS regression (``pls_predict_batch``) trained on paired
+Detector (xgb AUs) + MPDetector (52 blendshapes) outputs from ~10K CelebV-HQ
+celebrity videos (~350K frames). Cheong / Py-Feat-tutorial-06 style: linear
+features only, no pairwise interactions, no clipping at training. 3-fold
+GroupKFold (by video_id) OOS variance-weighted R² = 0.236 ± 0.008.
+
+Weights are downloaded from HuggingFace Hub at first use:
+    https://huggingface.co/py-feat/bs_to_au → ``bs_to_au_pls_v2.npz``
+
+Also defines a **dlib-68 → MediaPipe-478 landmark index mapping** so the
+existing dlib-based AU muscle-polygon heatmap drawing can be reused on
+MPDetector output.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from feat.utils import hf_hub_download_with_fallback
+
+# ---------------------------------------------------------------------
+# Learned PLS regression: 52 MP blendshapes → 20 AU intensities
+# ---------------------------------------------------------------------
+_PLS_WEIGHTS = None
+_PLS_REPO_ID = "py-feat/bs_to_au"
+_PLS_FILENAME = "bs_to_au_pls_v2.npz"
+
+
+def _load_pls_weights():
+    """Lazy-load PLS weights from HuggingFace Hub. Cached after first call."""
+    global _PLS_WEIGHTS
+    if _PLS_WEIGHTS is not None:
+        return _PLS_WEIGHTS
+
+    path = hf_hub_download_with_fallback(
+        repo_id=_PLS_REPO_ID,
+        filename=_PLS_FILENAME,
+    )
+    z = np.load(path, allow_pickle=False)
+    _PLS_WEIGHTS = {
+        "coef": z["coef"].astype(np.float32),                    # (52, 20)
+        "intercept": z["intercept"].astype(np.float32),          # (20,)
+        "blendshape_columns": [str(s) for s in z["bs_columns"]],
+        "au_columns": [str(s) for s in z["au_columns"]],
+    }
+    return _PLS_WEIGHTS
+
+
+def pls_predict_batch(
+    blendshape_array: np.ndarray, clip: bool = True,
+) -> np.ndarray:
+    """(N, 52) MP blendshapes → (N, 20) AU intensities via Cheong-style PLS.
+
+    Trained on ~350K frames from 10K CelebV-HQ wild-celebrity videos, paired
+    (xgb AU intensity, MP blendshape coefficient) per frame, pose-filtered to
+    |yaw| ≤ 40° and |pitch| ≤ 30°. PLS-2 with n_components=20 (full rank),
+    linear features only — pairwise BS interactions were tested and degraded
+    out-of-sample R², so they are NOT used.
+
+    3-fold GroupKFold (by video_id) variance-weighted R² = 0.236 ± 0.008.
+    Per-AU R² is strongest on AU06/12/43 (~0.50), weakest on AU11/15/28 (<0.10).
+
+    See `https://huggingface.co/py-feat/bs_to_au` for the model card.
+
+    Args:
+        blendshape_array: (N, 52) array of MP blendshape coefficients. Columns
+            must follow MediaPipe FaceLandmarker order (matches MPDetector
+            output); see ``_PLS_WEIGHTS["blendshape_columns"]`` after load.
+        clip: if True (default), output is clipped to [0, 1] for display
+            consistency with FACS intensity convention.
+
+    Returns:
+        (N, 20) array of AU intensities in py-feat's standard order.
+    """
+    w = _load_pls_weights()
+    out = blendshape_array.astype(np.float32) @ w["coef"] + w["intercept"]
+    return np.clip(out, 0.0, 1.0) if clip else out
+
+
+# ---------------------------------------------------------------------
+# dlib-68 → MediaPipe Face Mesh-478 index correspondence
+# ---------------------------------------------------------------------
+DLIB68_FROM_MP478: list[int] = [
+    # Jaw 0-16
+    127, 234, 93, 132, 58, 172, 136, 150, 176, 148, 152, 377, 400, 379, 365, 397, 356,
+    # Left eyebrow 17-21
+    70, 63, 105, 66, 107,
+    # Right eyebrow 22-26
+    336, 296, 334, 293, 300,
+    # Nose 27-30 bridge
+    168, 6, 195, 4,
+    # Nose tip 31-35
+    240, 75, 1, 305, 460,
+    # Left eye 36-41
+    33, 160, 158, 133, 153, 144,
+    # Right eye 42-47
+    362, 385, 387, 263, 373, 380,
+    # Outer lip 48-59
+    61, 39, 37, 0, 267, 269, 291, 405, 314, 17, 84, 181,
+    # Inner lip 60-67
+    78, 82, 13, 312, 308, 317, 14, 87,
+]
+assert len(DLIB68_FROM_MP478) == 68
+
+
+def mp478_row_to_dlib68_view(row) -> dict:
+    """Build a dict with x_0..x_67 / y_0..y_67 keys by sampling
+    the matching MediaPipe-478 landmarks."""
+    view: dict = {}
+    for dlib_idx, mp_idx in enumerate(DLIB68_FROM_MP478):
+        view[f"x_{dlib_idx}"] = row.get(f"x_{mp_idx}", np.nan)
+        view[f"y_{dlib_idx}"] = row.get(f"y_{mp_idx}", np.nan)
+    for k in (
+        "FaceRectX", "FaceRectY", "FaceRectWidth", "FaceRectHeight",
+        "Pitch", "Roll", "Yaw",
+    ):
+        if k in row.index if hasattr(row, "index") else k in row:
+            view[k] = row[k]
+    return view

--- a/feat/utils/blendshape_to_au.py
+++ b/feat/utils/blendshape_to_au.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import numpy as np
 
-from feat.utils import hf_hub_download_with_fallback
+from huggingface_hub import hf_hub_download
+
+from feat.utils.io import get_resource_path
 
 # ---------------------------------------------------------------------
 # Learned PLS regression: 52 MP blendshapes → 20 AU intensities
@@ -34,9 +36,10 @@ def _load_pls_weights():
     if _PLS_WEIGHTS is not None:
         return _PLS_WEIGHTS
 
-    path = hf_hub_download_with_fallback(
+    path = hf_hub_download(
         repo_id=_PLS_REPO_ID,
         filename=_PLS_FILENAME,
+        cache_dir=get_resource_path(),
     )
     z = np.load(path, allow_pickle=False)
     _PLS_WEIGHTS = {
@@ -65,18 +68,43 @@ def pls_predict_batch(
     See `https://huggingface.co/py-feat/bs_to_au` for the model card.
 
     Args:
-        blendshape_array: (N, 52) array of MP blendshape coefficients. Columns
-            must follow MediaPipe FaceLandmarker order (matches MPDetector
-            output); see ``_PLS_WEIGHTS["blendshape_columns"]`` after load.
+        blendshape_array: blendshape coefficients in MediaPipe FaceLandmarker
+            order (matches MPDetector output). Either a 1-D ``(52,)`` vector
+            for a single face or a 2-D ``(N, 52)`` batch. See
+            ``_PLS_WEIGHTS["blendshape_columns"]`` after load for the exact
+            column names.
         clip: if True (default), output is clipped to [0, 1] for display
             consistency with FACS intensity convention.
 
     Returns:
-        (N, 20) array of AU intensities in py-feat's standard order.
+        AU intensities in py-feat's standard order. Shape matches input batching:
+        ``(20,)`` for a 1-D input, ``(N, 20)`` for a 2-D input.
     """
     w = _load_pls_weights()
-    out = blendshape_array.astype(np.float32) @ w["coef"] + w["intercept"]
-    return np.clip(out, 0.0, 1.0) if clip else out
+    bs = np.asarray(blendshape_array, dtype=np.float32)
+    n_features = w["coef"].shape[0]
+    if bs.ndim == 1:
+        if bs.shape[0] != n_features:
+            raise ValueError(
+                f"Expected 1-D input of length {n_features}, got {bs.shape[0]}."
+            )
+        bs = bs.reshape(1, -1)
+        squeeze_out = True
+    elif bs.ndim == 2:
+        if bs.shape[1] != n_features:
+            raise ValueError(
+                f"Expected 2-D input with {n_features} columns, got shape {bs.shape}."
+            )
+        squeeze_out = False
+    else:
+        raise ValueError(
+            f"blendshape_array must be 1-D ({n_features},) or 2-D (N, {n_features}); "
+            f"got ndim={bs.ndim}, shape={bs.shape}."
+        )
+    out = bs @ w["coef"] + w["intercept"]
+    if clip:
+        out = np.clip(out, 0.0, 1.0)
+    return out[0] if squeeze_out else out
 
 
 # ---------------------------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,12 @@ universal = 1
 [aliases]
 test = pytest
 
+[tool:pytest]
+# Custom markers registered so ``pytest -m`` selectors don't warn.
+# Use ``-m "not network"`` for offline runs.
+markers =
+    network: tests that perform real HuggingFace Hub or other network I/O
+
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 # Skips: build artifacts, generated files, binary fixtures, and Jupyter


### PR DESCRIPTION
## Summary

- Adds a clean Cheong / Py-Feat-tutorial-06 style PLS regressor mapping 52 MP blendshapes → 20 FACS AU intensities
- Trained on ~350K frames from ~10K CelebV-HQ celebrity videos (vs the prior 1K-video Ridge-with-pairwise-interactions approach)
- Weights ship from HuggingFace Hub at first use: [py-feat/bs_to_au](https://huggingface.co/py-feat/bs_to_au)
- Single matmul inference; ~9 KB cached weights

## Why

The prior orphaned ``regress_batch`` path used Ridge with pairwise blendshape interactions trained on only 1K videos. We tested pairwise interactions empirically on the 10K dataset and they **degrade out-of-sample R²** (verified in nested CV). Linear features only is the right inductive bias here.

The Ozel deterministic mapping was also dropped — no consistent advantage on paired-detector data and added inference branching for marginal value.

## Performance (3-fold GroupKFold by video_id, OOS)

- Variance-weighted **R² = 0.236 ± 0.008** across all 20 AUs
- Per-AU R² strongest on AU06/12/43 (~0.50), weakest on AU11/15/28 (<0.10) — these are visually subtle or rare AUs
- For comparison, the prior Ridge-with-pairwise-interactions+output-clipping reported R²=0.31, but that advantage was driven by the post-hoc [0,1] clip; without clipping PLS ties or wins on the same fold

## Module changes

| Item | Action |
|---|---|
| ``pls_predict_batch(blendshape_array)`` | **NEW**: single matmul, lazy HF Hub download |
| ``regress_batch`` (Ridge + pairs) | **REMOVED**: orphaned 1K-trained path; weights file (``blendshape_to_au_ridge.json``) was never committed |
| ``ozel_predict_batch`` and Ozel table | **REMOVED**: deterministic fallback didn't pull its weight |
| ``DLIB68_FROM_MP478`` index map + ``mp478_row_to_dlib68_view`` | **KEPT**: still useful for downstream plotting |

No internal callers broke (no imports of the dropped functions in feat/, no tests referenced them).

## Test plan

- [ ] ``hf_hub_download_with_fallback`` retrieves NPZ from `py-feat/bs_to_au` (verified manually before PR)
- [ ] ``pls_predict_batch`` returns expected (N, 20) shape with values in [0, 1] when ``clip=True``
- [ ] No internal imports of removed ``regress_batch`` / ``ozel_predict_batch`` (verified via ``grep -rn``)
- [ ] CI (when run): existing tests still pass

## Related work (follow-up PRs in this series)

This is **PR1 of a planned sequence**:
- **PR2** (next): replace ``feat.plotting.load_viz_model`` default to a re-trained PLS model on 10K CelebV-HQ ([py-feat/au_to_landmarks](https://huggingface.co/py-feat/au_to_landmarks)) — drop-in, much higher R² than v1, legacy v1 preserved in same HF repo for rollback
- **PR3**: MPDetector surfaces 20 predicted AU columns alongside the 52 blendshape columns (consumes this PR's loader)
- **PR4**: MPDetector plotting parity (works with same plot_face/plot_detections API as Detector)
- **PR5**: New AU → 478-pt MP mesh plotting (opt-in; [py-feat/au_to_mesh](https://huggingface.co/py-feat/au_to_mesh))
- **PR6**: 68-pt → 478-pt mesh bridge ([py-feat/landmarks68_to_mesh478](https://huggingface.co/py-feat/landmarks68_to_mesh478)) so default-Detector users can render the rich MP mesh
- **PR7**: Plotting cleanup + optional Plotly backend for interactive 3D