### PR TITLE
feat(Fex): unified dlib-68 landmark accessor; plot_detections works for MPDetector

### DIFF
--- a/feat/data.py
+++ b/feat/data.py
@@ -511,35 +511,32 @@ class Fex(DataFrame):
         and downstream consumers don't have to branch on the underlying topology:
 
         - **Detector** (``Detector(landmark_model="mobilefacenet")``) outputs
-          136-d ``[x_0..x_67, y_0..y_67]`` directly — returned as-is.
-        - **MPDetector** outputs 1434-d ``[x_0..x_477 | y_0..y_477 | z_0..z_477]``
-          (the 478-vertex MediaPipe FaceMesh in image-space pixels). The 68
-          dlib-equivalent vertices are sampled via ``DLIB68_FROM_MP478``
-          (see ``feat.utils.blendshape_to_au``); z is dropped.
+          136-d ``[x_0..x_67, y_0..y_67]`` (axis-major) — returned as-is.
+        - **MPDetector** outputs the 478-vertex MediaPipe FaceMesh as 1434
+          named columns ``x_i / y_i / z_i`` (i in 0..477), in image-space
+          pixels. The 68 dlib-equivalent vertices are sampled by name via
+          ``DLIB68_FROM_MP478`` (see ``feat.utils.blendshape_to_au``); z dropped.
 
         Args:
             row: optional pandas Series (single Fex row). If ``None``, operates
-                on all rows of ``self`` and returns shape ``(n_rows, 68)`` for
-                each axis. Otherwise returns shape ``(68,)`` per axis.
+                on all rows of ``self`` and returns shape ``(n_rows, 68)`` per
+                axis. Otherwise returns shape ``(68,)`` per axis.
 
         Returns:
             (x, y): two numpy arrays of dlib-68 layout. Shapes ``(68,)`` if
                 ``row`` is given, else ``(n_rows, 68)``.
         """
+        if self.landmark_columns is None:
+            raise ValueError("landmark_columns is not set on this Fex")
         n_lm_cols = len(self.landmark_columns)
         source = self if row is None else row
 
         if n_lm_cols == 136:
-            # Detector path — already dlib-68
-            arr = (source[self.landmark_columns].values
-                   if row is None
-                   else source[self.landmark_columns].values)
-            arr = np.atleast_2d(arr) if row is None else arr
-            x = arr[:, :68] if row is None else arr[:68]
-            y = arr[:, 68:] if row is None else arr[68:]
-            return x.astype(np.float64), y.astype(np.float64)
+            arr = source[self.landmark_columns].values.astype(np.float64)
+            if row is None:
+                return arr[:, :68], arr[:, 68:]
+            return arr[:68], arr[68:]
         elif n_lm_cols == 1434:
-            # MPDetector path — 478-vertex 3D mesh; sample 68-pt dlib subset
             x_cols = [f"x_{i}" for i in DLIB68_FROM_MP478]
             y_cols = [f"y_{i}" for i in DLIB68_FROM_MP478]
             x = source[x_cols].values.astype(np.float64)

--- a/feat/data.py
+++ b/feat/data.py
@@ -41,6 +41,7 @@ from feat.plotting import (
     emotion_annotation_position,
 )
 from feat.pretrained import AU_LANDMARK_MAP
+from feat.utils.blendshape_to_au import DLIB68_FROM_MP478
 from scipy.signal import convolve
 from scipy.stats import ttest_1samp, ttest_ind
 import matplotlib.pyplot as plt
@@ -502,6 +503,53 @@ class Fex(DataFrame):
             "Fex.landmark has now been renamed to Fex.landmarks", DeprecationWarning
         )
         return self[self.landmark_columns]
+
+    def landmarks_dlib68_xy(self, row=None):
+        """Return (x, y) arrays in dlib-68 layout, regardless of source detector.
+
+        Provides a uniform 2D-landmark interface across detectors so plotting
+        and downstream consumers don't have to branch on the underlying topology:
+
+        - **Detector** (``Detector(landmark_model="mobilefacenet")``) outputs
+          136-d ``[x_0..x_67, y_0..y_67]`` directly — returned as-is.
+        - **MPDetector** outputs 1434-d ``[x_0..x_477 | y_0..y_477 | z_0..z_477]``
+          (the 478-vertex MediaPipe FaceMesh in image-space pixels). The 68
+          dlib-equivalent vertices are sampled via ``DLIB68_FROM_MP478``
+          (see ``feat.utils.blendshape_to_au``); z is dropped.
+
+        Args:
+            row: optional pandas Series (single Fex row). If ``None``, operates
+                on all rows of ``self`` and returns shape ``(n_rows, 68)`` for
+                each axis. Otherwise returns shape ``(68,)`` per axis.
+
+        Returns:
+            (x, y): two numpy arrays of dlib-68 layout. Shapes ``(68,)`` if
+                ``row`` is given, else ``(n_rows, 68)``.
+        """
+        n_lm_cols = len(self.landmark_columns)
+        source = self if row is None else row
+
+        if n_lm_cols == 136:
+            # Detector path — already dlib-68
+            arr = (source[self.landmark_columns].values
+                   if row is None
+                   else source[self.landmark_columns].values)
+            arr = np.atleast_2d(arr) if row is None else arr
+            x = arr[:, :68] if row is None else arr[:68]
+            y = arr[:, 68:] if row is None else arr[68:]
+            return x.astype(np.float64), y.astype(np.float64)
+        elif n_lm_cols == 1434:
+            # MPDetector path — 478-vertex 3D mesh; sample 68-pt dlib subset
+            x_cols = [f"x_{i}" for i in DLIB68_FROM_MP478]
+            y_cols = [f"y_{i}" for i in DLIB68_FROM_MP478]
+            x = source[x_cols].values.astype(np.float64)
+            y = source[y_cols].values.astype(np.float64)
+            return x, y
+        else:
+            raise ValueError(
+                f"Unexpected landmark_columns length ({n_lm_cols}); expected 136 "
+                "(dlib-68) or 1434 (MP-478 mesh)."
+            )
 
     @property
     def poses(self):
@@ -1773,9 +1821,11 @@ class Fex(DataFrame):
                         )
 
                     if faces == "landmarks":
-                        landmark = row[self.landmark_columns].values
-                        currx = landmark[:68]
-                        curry = landmark[68:]
+                        # Branch on landmark topology: dlib-68 (136 cols) returns
+                        # as-is; MP-478 (1434 cols) samples the 68 dlib-equivalent
+                        # vertices via DLIB68_FROM_MP478 so the same draw_lineface
+                        # path works for both detectors.
+                        currx, curry = self.landmarks_dlib68_xy(row=row)
 
                         # facelines
                         face_ax = draw_lineface(

--- a/feat/tests/test_landmarks_dlib68_xy.py
+++ b/feat/tests/test_landmarks_dlib68_xy.py
@@ -1,0 +1,132 @@
+"""Tests for ``Fex.landmarks_dlib68_xy``.
+
+Pins the dispatch contract for the unified dlib-68 landmark accessor that
+makes ``plot_detections(faces='landmarks')`` work on both Detector (136-d)
+and MPDetector (1434-d) Fex objects.
+
+All tests are offline — synthetic Fex objects with known landmark values
+are sufficient since the method is pure DataFrame indexing.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from feat.data import Fex
+from feat.utils import openface_2d_landmark_columns, MP_LANDMARK_COLUMNS
+from feat.utils.blendshape_to_au import DLIB68_FROM_MP478
+
+
+# ---------------------------------------------------------------------
+# Synthetic Fex fixtures
+# ---------------------------------------------------------------------
+
+def _make_dlib68_fex(n_rows: int = 3) -> Fex:
+    """Detector-style Fex: 136 landmark columns in axis-major layout
+    [x_0..x_67, y_0..y_67]. Encodes ``x_i = i`` and ``y_i = 100 + i`` per row
+    so tests can verify positional indexing is correct."""
+    data = {}
+    for i in range(68):
+        data[f"x_{i}"] = np.full(n_rows, float(i))
+        data[f"y_{i}"] = np.full(n_rows, 100.0 + i)
+    df = pd.DataFrame(data, columns=openface_2d_landmark_columns)
+    return Fex(df, landmark_columns=openface_2d_landmark_columns)
+
+
+def _make_mp478_fex(n_rows: int = 3) -> Fex:
+    """MPDetector-style Fex: 1434 landmark columns named x_i / y_i / z_i for
+    i in 0..477 (interleaved per-vertex layout). Encodes ``x_i = i``,
+    ``y_i = 1000 + i``, ``z_i = 2000 + i`` so tests can confirm the
+    ``DLIB68_FROM_MP478`` index map is honored."""
+    data = {}
+    for i in range(478):
+        data[f"x_{i}"] = np.full(n_rows, float(i))
+        data[f"y_{i}"] = np.full(n_rows, 1000.0 + i)
+        data[f"z_{i}"] = np.full(n_rows, 2000.0 + i)
+    df = pd.DataFrame(data, columns=MP_LANDMARK_COLUMNS)
+    return Fex(df, landmark_columns=MP_LANDMARK_COLUMNS)
+
+
+# ---------------------------------------------------------------------
+# Detector path (136-d, axis-major)
+# ---------------------------------------------------------------------
+
+class TestDlib68Path:
+    def test_dataframe_form_returns_2d(self):
+        fex = _make_dlib68_fex(n_rows=4)
+        x, y = fex.landmarks_dlib68_xy()
+        assert x.shape == (4, 68)
+        assert y.shape == (4, 68)
+
+    def test_dataframe_form_values_axis_major_split(self):
+        """x[:, i] == i and y[:, i] == 100 + i for the canonical Detector layout."""
+        fex = _make_dlib68_fex(n_rows=2)
+        x, y = fex.landmarks_dlib68_xy()
+        for i in range(68):
+            assert (x[:, i] == float(i)).all(), f"x[{i}] mismatch"
+            assert (y[:, i] == 100.0 + i).all(), f"y[{i}] mismatch"
+
+    def test_row_form_returns_1d(self):
+        fex = _make_dlib68_fex(n_rows=3)
+        x, y = fex.landmarks_dlib68_xy(row=fex.iloc[1])
+        assert x.shape == (68,)
+        assert y.shape == (68,)
+        assert (x == np.arange(68, dtype=np.float64)).all()
+        assert (y == 100.0 + np.arange(68, dtype=np.float64)).all()
+
+
+# ---------------------------------------------------------------------
+# MPDetector path (1434-d, named-column lookup)
+# ---------------------------------------------------------------------
+
+class TestMp478Path:
+    def test_dataframe_form_returns_2d(self):
+        fex = _make_mp478_fex(n_rows=2)
+        x, y = fex.landmarks_dlib68_xy()
+        assert x.shape == (2, 68)
+        assert y.shape == (2, 68)
+
+    def test_dataframe_form_samples_dlib68_indices(self):
+        """For dlib slot j, the returned x value must equal MP vertex
+        ``DLIB68_FROM_MP478[j]`` (encoded as float). Same for y, offset by 1000."""
+        fex = _make_mp478_fex(n_rows=2)
+        x, y = fex.landmarks_dlib68_xy()
+        for j, mp_idx in enumerate(DLIB68_FROM_MP478):
+            assert (x[:, j] == float(mp_idx)).all(), \
+                f"dlib idx {j} -> MP {mp_idx} mismatch on x"
+            assert (y[:, j] == 1000.0 + mp_idx).all(), \
+                f"dlib idx {j} -> MP {mp_idx} mismatch on y"
+
+    def test_row_form_returns_1d_correct_indices(self):
+        fex = _make_mp478_fex(n_rows=3)
+        x, y = fex.landmarks_dlib68_xy(row=fex.iloc[2])
+        assert x.shape == (68,)
+        assert y.shape == (68,)
+        # Spot-check: dlib jaw center idx 8 maps to MP 176 (per DLIB68_FROM_MP478),
+        # idx 10 maps to MP 152.
+        assert x[8] == 176.0
+        assert y[8] == 1176.0
+        assert x[10] == 152.0
+        assert y[10] == 1152.0
+
+
+# ---------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------
+
+class TestErrorPaths:
+    def test_none_landmark_columns_raises(self):
+        """A Fex without landmark_columns set should give a clear error,
+        not a TypeError from len(None)."""
+        fex = Fex(pd.DataFrame({"a": [1, 2]}), landmark_columns=None)
+        with pytest.raises(ValueError, match=r"landmark_columns is not set"):
+            fex.landmarks_dlib68_xy()
+
+    def test_unexpected_length_raises(self):
+        """Anything that isn't 136 (dlib) or 1434 (MP-478) is rejected."""
+        cols = [f"x_{i}" for i in range(50)] + [f"y_{i}" for i in range(50)]
+        df = pd.DataFrame({c: [0.0, 0.0] for c in cols}, columns=cols)
+        fex = Fex(df, landmark_columns=cols)
+        with pytest.raises(ValueError, match=r"Unexpected landmark_columns length"):
+            fex.landmarks_dlib68_xy()


### PR DESCRIPTION
## Summary

- Adds ``Fex.landmarks_dlib68_xy()`` — single dispatch helper that returns 68-point landmarks in dlib layout regardless of source detector
- ``Fex.plot_detections(faces=""landmarks"")`` now works on MPDetector output (was silently broken before)
- No external API changes — additive

## Why

``plot_detections`` previously assumed 136-d dlib landmark layout:

```python
landmark = row[self.landmark_columns].values
currx = landmark[:68]
curry = landmark[68:]
```

For MPDetector Fex (1434-d MP-478 mesh), ``landmark[:68]`` returns the first 68 x-coords (correct) but ``landmark[68:]`` returns ``x_68..x_477 + all_y + all_z`` — wrong, and the rendered plot is garbage. This PR makes the dispatch explicit and centralizes the topology logic in one Fex method.

## Implementation

- Import ``DLIB68_FROM_MP478`` from ``feat.utils.blendshape_to_au`` (the dlib→MP index correspondence the legacy utility already shipped, now consumed externally)
- New ``Fex.landmarks_dlib68_xy(row=None)`` method:
  - Detects topology from ``len(self.landmark_columns)`` (136 → dlib-68; 1434 → MP-478)
  - For dlib path: returns ``[x_0..x_67]`` and ``[y_0..y_67]`` directly
  - For MP path: samples 68 vertices via ``DLIB68_FROM_MP478``; drops z
  - Returns ``(x, y)`` arrays — shape ``(68,)`` if a row is given, else ``(n_rows, 68)``
- ``plot_detections`` ``faces=""landmarks""`` branch now calls the helper instead of slicing the raw landmark array

## Backward compatibility

| Path | Behavior |
|---|---|
| Detector Fex (136-d) | identical to before |
| MPDetector Fex (1434-d) | ``plot_detections`` now works (was producing garbage) |
| External API | additive — new method, no signatures changed |

## Test plan

- [ ] ``Detector(...).detect(img).plot_detections(faces=""landmarks"")`` unchanged behavior
- [ ] ``MPDetector(...).detect(img).plot_detections(faces=""landmarks"")`` produces a coherent dlib-style face overlay (was broken before)
- [ ] ``Fex.landmarks_dlib68_xy()`` returns ``(68,)`` arrays for a single row from either detector
- [ ] ``Fex.landmarks_dlib68_xy()`` returns ``(n_rows, 68)`` arrays when called on the whole Fex
- [ ] CI: existing tests still pass

## Dependency

This PR's base is set to ``feat/v0.7-mpdetector-au-cols`` (PR #302), which itself stacks on ``feat/v0.7-pls-bs-to-au`` (PR #300). The constant ``DLIB68_FROM_MP478`` lives in PR #300's ``feat/utils/blendshape_to_au.py``. Once #300 + #302 merge, I'll rebase this PR's base to ``v0.7-dev`` for a clean merge.

## Related work

This is **PR4 of a planned sequence**:
- PR1 (#300): BS→AU PLS regressor
- PR2 (#301): default AU→landmarks viz model swap
- PR3 (#302): MPDetector AU column surfacing
- **PR4 (this)**: MPDetector plotting parity
- PR5 (next): AU → 478-pt mesh visualization (opt-in)
- PR6: 68 → 478 mesh bridge
- PR7: Plotting cleanup + Plotly interactive backend