### PR TITLE
feat(plotting): opt-in AU → 478-pt MediaPipe FaceMesh viz

### DIFF
--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1367,6 +1367,239 @@ def _load_pls_v2_from_hub(verbose=False):
     return _PLS_V2_VIZ_MODEL
 
 
+# ---------------------------------------------------------------------
+# AU + pose → 478-vertex MediaPipe FaceMesh (opt-in 3D visualization).
+# Mirrors the 68-pt landmark wrapper above. Output lives in a pose-canonical
+# frame anchored on stable upper-face landmarks (forehead + nose bridge +
+# canthi). See https://huggingface.co/py-feat/au_to_mesh for the model card.
+# ---------------------------------------------------------------------
+
+
+class PLSAUMeshModel:
+    """Wrapper around the v2 AU + pose → 478-vertex MP mesh PLS weights.
+
+    Mirrors the ``PLSAULandmarkModel`` interface (``.predict(au)``,
+    ``.n_components``) but emits the full 3D MediaPipe FaceMesh instead of
+    a 68-point dlib-style 2D landmark layout. Pose is held implicit-zero
+    at inference; the absorbed pose×AU interaction terms drop out
+    automatically. Inference is a single matmul.
+
+    Loaded by ``load_face_mesh_viz_model()``. Underlying weights live in
+    the ``py-feat/au_to_mesh`` HF Hub repo.
+    """
+
+    def __init__(
+        self,
+        coef,
+        intercept,
+        au_columns,
+        pose_columns,
+        mean_aligned_mesh,
+        model_name="au_to_mesh_pls_v2",
+    ):
+        # coef shape: (23, 1434); the deployed slice with pose absorbed
+        self._coef = np.asarray(coef, dtype=np.float32)
+        self._intercept = np.asarray(intercept, dtype=np.float32)
+        self.au_columns = list(au_columns)
+        self.pose_columns = list(pose_columns)
+        # Number of AU input features the user passes (pose is implicit-zero)
+        self.n_components = len(self.au_columns)
+        # Population-mean rest mesh in pose-canonical frame; useful as a
+        # reference baseline for visualizing AU deltas.
+        self.mean_aligned_mesh = np.asarray(mean_aligned_mesh, dtype=np.float32)
+        self.model_name_ = model_name
+
+    def predict(self, au):
+        """Predict (n_samples, 1434) flat mesh coords from (n_samples, 20) AU.
+
+        The 1434-d flat layout is **axis-major**: ``[x_0..x_477 | y_0..y_477
+        | z_0..z_477]`` — matching how training stacks the per-vertex columns
+        ``x_i / y_i / z_i``. Use ``predict_face_mesh()`` for an ``(n, 478, 3)``
+        reshape with the right vertex ordering.
+
+        Pose channels are zero-padded so the deployed coef matrix can be
+        used directly. Output is in the Procrustes-aligned canonical frame.
+        """
+        au = np.asarray(au, dtype=np.float32)
+        if au.ndim == 1:
+            au = au.reshape(1, -1)
+        n = au.shape[0]
+        x = np.zeros((n, self._coef.shape[0]), dtype=np.float32)
+        x[:, : au.shape[1]] = au
+        # Pose channels remain zero (already initialized)
+        return x @ self._coef + self._intercept
+
+    def __repr__(self):
+        return (
+            f"PLSAUMeshModel(model_name='{self.model_name_}', "
+            f"n_components={self.n_components}, "
+            f"output_shape=(n_samples, 478, 3))"
+        )
+
+
+# Module-level cache; the HF download is already cached by huggingface_hub.
+_PLS_V2_MESH_MODEL = None
+
+
+def _load_pls_au_to_mesh_v2_from_hub(verbose=False):
+    """Download (cached) and wrap the v2 AU→mesh PLS NPZ from HuggingFace Hub."""
+    global _PLS_V2_MESH_MODEL
+    if _PLS_V2_MESH_MODEL is not None:
+        return _PLS_V2_MESH_MODEL
+
+    if verbose:
+        print("Loading v2 PLS AU→mesh model from HuggingFace Hub")
+    path = hf_hub_download(
+        repo_id="py-feat/au_to_mesh",
+        filename="au_to_mesh_pls_v2.npz",
+        cache_dir=get_resource_path(),
+    )
+    z = np.load(path, allow_pickle=False)
+    _PLS_V2_MESH_MODEL = PLSAUMeshModel(
+        coef=z["coef"],
+        intercept=z["intercept"],
+        au_columns=[str(s) for s in z["au_columns"]],
+        pose_columns=[str(s) for s in z["pose_columns"]],
+        mean_aligned_mesh=z["mean_aligned_mesh"],
+        model_name="au_to_mesh_pls_v2",
+    )
+    return _PLS_V2_MESH_MODEL
+
+
+def load_face_mesh_viz_model(verbose=False):
+    """Load the AU + pose → 478-pt MediaPipe FaceMesh PLS visualization model.
+
+    Returns a ``PLSAUMeshModel`` whose ``.predict(au)`` produces the 478-vertex
+    3D mesh (flattened to 1434-d) in a pose-canonical frame. Use
+    ``predict_face_mesh()`` for a (478, 3) reshape, or ``plot_face_mesh()`` for
+    a quick 3D wireframe.
+
+    Args:
+        verbose: print a status line when first downloading.
+
+    Returns:
+        PLSAUMeshModel
+    """
+    return _load_pls_au_to_mesh_v2_from_hub(verbose=verbose)
+
+
+def predict_face_mesh(au, model=None):
+    """Predict the 3D MediaPipe FaceMesh from AU intensities.
+
+    Args:
+        au: AU intensity vector or batch. Shape ``(20,)`` or ``(n, 20)`` — the
+            standard ``AU_LANDMARK_MAP['Feat']`` order.
+        model: optional ``PLSAUMeshModel``; defaults to the cached v2 model.
+
+    Returns:
+        Predicted mesh in pose-canonical pixel coords. Shape ``(478, 3)`` for
+        a 1-D AU input, ``(n, 478, 3)`` for a batched 2-D input.
+    """
+    if model is None:
+        model = load_face_mesh_viz_model()
+    if not isinstance(model, PLSAUMeshModel):
+        raise ValueError(
+            "model must be a PLSAUMeshModel "
+            "(returned by feat.plotting.load_face_mesh_viz_model())"
+        )
+    au_arr = np.asarray(au)
+    is_single = au_arr.ndim == 1
+    if au_arr.ndim == 1:
+        au_arr = au_arr.reshape(1, -1)
+    if au_arr.shape[1] != model.n_components:
+        raise ValueError(
+            f"au vector must be length {model.n_components}; got {au_arr.shape[1]}."
+        )
+    flat = model.predict(au_arr)  # (n, 1434), axis-major [x | y | z]
+    xs = flat[:, :478]
+    ys = flat[:, 478:956]
+    zs = flat[:, 956:]
+    mesh = np.stack([xs, ys, zs], axis=-1)  # (n, 478, 3)
+    return mesh[0] if is_single else mesh
+
+
+def plot_face_mesh(
+    au=None,
+    model=None,
+    ax=None,
+    color="black",
+    linewidth=0.6,
+    alpha=0.9,
+    view_init=(0, -90),
+):
+    """3D wireframe of the predicted face mesh. Opt-in alternative to ``plot_face``.
+
+    Renders the canonical MediaPipe contours (lips + eyes + eyebrows + face
+    oval) from the predicted 478-vertex mesh. For a quick reference plot,
+    leave ``au=None`` to draw the population-mean rest mesh.
+
+    Coordinate frame: the trained mesh uses standard math convention with
+    ``+X`` lateral, ``+Y`` up (forehead at ~+8, chin at ~-8), ``+Z`` out of
+    the face. We map data ``(x, y, z)`` to matplotlib ``(x, z, y)`` so the
+    default 3D viewport renders the face standing upright with Z (depth) into
+    the screen — matching how a viewer sees the face.
+
+    Args:
+        au: AU intensity vector ``(20,)`` in ``AU_LANDMARK_MAP['Feat']`` order.
+            ``None`` plots the rest mesh.
+        model: optional ``PLSAUMeshModel``; defaults to the cached v2 model.
+        ax: optional matplotlib 3D axis. If ``None``, a new figure is created.
+        color, linewidth, alpha: line styling.
+        view_init: ``(elev, azim)`` matplotlib view angles. Default frames
+            the face front-on; rotate ``azim`` to see profile.
+
+    Returns:
+        The matplotlib 3D axis with the wireframe drawn.
+    """
+    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3d projection)
+    from feat.utils.mp_plotting import FaceLandmarksConnections
+
+    if au is None:
+        if model is None:
+            model = load_face_mesh_viz_model()
+        verts = model.mean_aligned_mesh
+    else:
+        verts = predict_face_mesh(au, model=model)
+        if verts.ndim != 2:
+            raise ValueError(
+                "plot_face_mesh expects a single AU vector; pass one face at a time. "
+                "For batched predictions use predict_face_mesh(au_batch)."
+            )
+
+    if ax is None:
+        fig = plt.figure(figsize=(5, 5))
+        ax = fig.add_subplot(111, projection="3d")
+
+    # Map data (X, Y, Z) → matplotlib (X, Z, Y) so face renders upright with
+    # depth into the screen under the default viewport.
+    xs = verts[:, 0]
+    ys_mpl = verts[:, 2]
+    zs_mpl = verts[:, 1]
+
+    for conn in FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS:
+        a, b = conn.start, conn.end
+        ax.plot(
+            [xs[a], xs[b]], [ys_mpl[a], ys_mpl[b]], [zs_mpl[a], zs_mpl[b]],
+            color=color, linewidth=linewidth, alpha=alpha,
+        )
+
+    # Equal aspect ratio so the face isn't squashed by mpl3d's default scaling.
+    extents = np.array([
+        [xs.min(), xs.max()],
+        [ys_mpl.min(), ys_mpl.max()],
+        [zs_mpl.min(), zs_mpl.max()],
+    ])
+    centers = extents.mean(axis=1)
+    half = (extents[:, 1] - extents[:, 0]).max() / 2
+    ax.set_xlim(centers[0] - half, centers[0] + half)
+    ax.set_ylim(centers[1] - half, centers[1] + half)
+    ax.set_zlim(centers[2] - half, centers[2] + half)
+    ax.set_box_aspect((1, 1, 1))
+    ax.view_init(elev=view_init[0], azim=view_init[1])
+    ax.set_axis_off()
+    return ax
+
+
 def load_viz_model(
     file_name=None,
     prefer_joblib_if_version_match=True,

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1418,11 +1418,17 @@ class PLSAUMeshModel:
         reshape with the right vertex ordering.
 
         Pose channels are zero-padded so the deployed coef matrix can be
-        used directly. Output is in the Procrustes-aligned canonical frame.
+        used directly. Output is in the Procrustes-aligned canonical frame
+        (units are GPA-aligned cm, not image pixels).
         """
         au = np.asarray(au, dtype=np.float32)
         if au.ndim == 1:
             au = au.reshape(1, -1)
+        if au.shape[1] != self.n_components:
+            raise ValueError(
+                f"au must have {self.n_components} columns "
+                f"(matching {self.au_columns}); got {au.shape[1]}."
+            )
         n = au.shape[0]
         x = np.zeros((n, self._coef.shape[0]), dtype=np.float32)
         x[:, : au.shape[1]] = au
@@ -1455,10 +1461,21 @@ def _load_pls_au_to_mesh_v2_from_hub(verbose=False):
         cache_dir=get_resource_path(),
     )
     z = np.load(path, allow_pickle=False)
+    au_columns = [str(s) for s in z["au_columns"]]
+    # Guard against silent mislabeling: callers pass `au` as a 20-d vector
+    # assuming index i corresponds to AU_LANDMARK_MAP["Feat"][i]. A re-trained
+    # npz with a shuffled column order would silently use wrong AU positions
+    # and produce subtly wrong mesh deformations. Refuse to load instead.
+    if au_columns != AU_LANDMARK_MAP["Feat"]:
+        raise RuntimeError(
+            "AU→mesh PLS au_columns drifted from AU_LANDMARK_MAP['Feat']. "
+            f"NPZ: {au_columns}; canonical: {AU_LANDMARK_MAP['Feat']}. "
+            "Re-train or update the canonical AU list."
+        )
     _PLS_V2_MESH_MODEL = PLSAUMeshModel(
         coef=z["coef"],
         intercept=z["intercept"],
-        au_columns=[str(s) for s in z["au_columns"]],
+        au_columns=au_columns,
         pose_columns=[str(s) for s in z["pose_columns"]],
         mean_aligned_mesh=z["mean_aligned_mesh"],
         model_name="au_to_mesh_pls_v2",
@@ -1492,8 +1509,9 @@ def predict_face_mesh(au, model=None):
         model: optional ``PLSAUMeshModel``; defaults to the cached v2 model.
 
     Returns:
-        Predicted mesh in pose-canonical pixel coords. Shape ``(478, 3)`` for
-        a 1-D AU input, ``(n, 478, 3)`` for a batched 2-D input.
+        Predicted mesh in pose-canonical-frame coordinates (GPA-aligned cm,
+        not image pixels). Shape ``(478, 3)`` for a 1-D AU input,
+        ``(n, 478, 3)`` for a batched 2-D input.
     """
     if model is None:
         model = load_face_mesh_viz_model()

--- a/feat/tests/test_face_mesh_viz.py
+++ b/feat/tests/test_face_mesh_viz.py
@@ -85,6 +85,16 @@ class TestPLSAUMeshModel:
                         + stub_mesh_model._intercept)
         np.testing.assert_allclose(out_wrapper, out_explicit, atol=1e-6)
 
+    def test_predict_rejects_wrong_au_width(self, stub_mesh_model):
+        """A user calling ``model.predict(au)`` directly (sklearn convention)
+        with the wrong number of AU columns must raise, not silently truncate
+        or zero-pad. Without this check the wrapper would accept e.g. a 19-d
+        vector and zero-pad it as if it were AU01..AU19 missing AU43."""
+        with pytest.raises(ValueError, match=r"must have 20 columns"):
+            stub_mesh_model.predict(np.zeros((2, 19), dtype=np.float32))
+        with pytest.raises(ValueError, match=r"must have 20 columns"):
+            stub_mesh_model.predict(np.zeros(19, dtype=np.float32))
+
     def test_n_components_is_20(self, stub_mesh_model):
         assert stub_mesh_model.n_components == 20
 
@@ -173,10 +183,67 @@ class TestPlotFaceMesh:
         with pytest.raises(ValueError, match=r"single AU vector"):
             plot_face_mesh(au=np.zeros((2, 20)), model=stub_mesh_model)
 
+    def test_data_y_maps_to_matplotlib_z(self, stub_mesh_model):
+        """Pin the data→matplotlib axis swap: data Y (vertical) renders along
+        matplotlib's Z. If someone "fixes" the swap to plot data verbatim,
+        the face would render lying down — locking this prevents regression.
+        """
+        ax = plot_face_mesh(au=None, model=stub_mesh_model)
+        verts = stub_mesh_model.mean_aligned_mesh
+        zlim = ax.get_zlim()
+        ylim = ax.get_ylim()
+        # The data-Y range must align with matplotlib's Z axis (the swap
+        # target). Compare span widths since matplotlib re-centers via
+        # set_zlim — small float32-vs-float64 rounding is absorbed.
+        data_y_span = float(verts[:, 1].max() - verts[:, 1].min())
+        data_z_span = float(verts[:, 2].max() - verts[:, 2].min())
+        mpl_z_span = zlim[1] - zlim[0]
+        mpl_y_span = ylim[1] - ylim[0]
+        # The largest data span is data-Y (~17). After the swap it lands on
+        # mpl-Z. Equal-aspect makes all three mpl axes share that max span.
+        assert mpl_z_span >= data_y_span - 1e-3, \
+            f"mpl Z span ({mpl_z_span:.3f}) should contain data Y span ({data_y_span:.3f})"
+        # Verify the swap is real, not just equal-aspect coincidence: data-Z
+        # span (~8) is smaller than data-Y span (~17), so if the swap were
+        # absent (data Z → mpl Z), mpl-Z span would only need to contain ~8.
+        assert data_y_span > data_z_span * 1.5, \
+            "fixture must have asymmetric Y/Z spans for the swap test to be meaningful"
+
 
 # ---------------------------------------------------------------------
 # Real HF Hub fetch — runs once, then hits cache.
 # ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# Drift guard — refuses to load a model with shuffled au_columns.
+# ---------------------------------------------------------------------
+
+class TestAuColumnDriftGuard:
+    def test_drift_raises_at_load(self, monkeypatch, tmp_path):
+        """If a future re-trained npz has shuffled au_columns,
+        _load_pls_au_to_mesh_v2_from_hub must refuse to load rather than
+        silently using wrong AU positions."""
+        from feat.pretrained import AU_LANDMARK_MAP
+
+        # Build a fake npz on disk with shuffled au_columns
+        bad_path = tmp_path / "au_to_mesh_bad.npz"
+        np.savez(
+            bad_path,
+            coef=np.zeros((23, 1434), dtype=np.float32),
+            intercept=np.zeros(1434, dtype=np.float32),
+            au_columns=np.array(AU_LANDMARK_MAP["Feat"][::-1]),  # reversed
+            pose_columns=np.array(["Pitch", "Yaw", "Roll"]),
+            mean_aligned_mesh=np.zeros((478, 3), dtype=np.float32),
+        )
+
+        # Bypass HF download: make hf_hub_download return our fake path
+        monkeypatch.setattr(plt_mod, "_PLS_V2_MESH_MODEL", None)
+        monkeypatch.setattr(plt_mod, "hf_hub_download",
+                            lambda **kwargs: str(bad_path))
+
+        with pytest.raises(RuntimeError, match=r"au_columns drifted"):
+            plt_mod._load_pls_au_to_mesh_v2_from_hub()
+
 
 @pytest.mark.network
 class TestRealMeshLoad:

--- a/feat/tests/test_face_mesh_viz.py
+++ b/feat/tests/test_face_mesh_viz.py
@@ -1,0 +1,198 @@
+"""Tests for the AU → 478-pt MediaPipe FaceMesh PLS visualization (PR5).
+
+Covers ``PLSAUMeshModel``, ``predict_face_mesh``, and ``plot_face_mesh``.
+Shape and reshape contracts run offline by stubbing the module-level cached
+model. One ``@pytest.mark.network`` test loads the real npz from HF Hub.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use("Agg")  # headless for test environments
+
+from feat import plotting as plt_mod
+from feat.plotting import (
+    PLSAUMeshModel,
+    load_face_mesh_viz_model,
+    plot_face_mesh,
+    predict_face_mesh,
+)
+
+
+# ---------------------------------------------------------------------
+# Fixture: install a stub PLSAUMeshModel into the module-level cache so
+# loader / predict / plot tests run offline without an HF fetch.
+# ---------------------------------------------------------------------
+
+@pytest.fixture
+def stub_mesh_model(monkeypatch):
+    """Inject a deterministic PLSAUMeshModel into the module cache.
+
+    Uses small per-axis values so the equal-aspect bbox math doesn't NaN,
+    and a non-zero coef so AU activation produces a measurable mesh delta.
+    """
+    rng = np.random.default_rng(0)
+    coef = (rng.standard_normal((23, 1434)).astype(np.float32) * 0.05)
+    # Intercept lays out a plausible canonical face mesh: x ∈ [-7, 7], y ∈
+    # [-9, 8], z ∈ [-1, 7] — matches the real model's ranges so the plot
+    # path's equal-aspect logic exercises a face-shaped bbox.
+    intercept = np.empty(1434, dtype=np.float32)
+    intercept[:478] = rng.uniform(-7, 7, 478)            # x
+    intercept[478:956] = rng.uniform(-9, 8, 478)         # y
+    intercept[956:] = rng.uniform(-1, 7, 478)            # z
+    au_cols = [
+        "AU01", "AU02", "AU04", "AU05", "AU06", "AU07", "AU09", "AU10",
+        "AU11", "AU12", "AU14", "AU15", "AU17", "AU20", "AU23", "AU24",
+        "AU25", "AU26", "AU28", "AU43",
+    ]
+    pose_cols = ["Pitch", "Yaw", "Roll"]
+    mean_mesh = np.column_stack([
+        intercept[:478], intercept[478:956], intercept[956:],
+    ])
+    model = PLSAUMeshModel(
+        coef=coef, intercept=intercept,
+        au_columns=au_cols, pose_columns=pose_cols,
+        mean_aligned_mesh=mean_mesh,
+    )
+    monkeypatch.setattr(plt_mod, "_PLS_V2_MESH_MODEL", model)
+    return model
+
+
+# ---------------------------------------------------------------------
+# PLSAUMeshModel
+# ---------------------------------------------------------------------
+
+class TestPLSAUMeshModel:
+    def test_predict_2d_batch_returns_flat(self, stub_mesh_model):
+        au = np.zeros((3, 20), dtype=np.float32)
+        out = stub_mesh_model.predict(au)
+        assert out.shape == (3, 1434)
+
+    def test_predict_1d_returns_2d_one_row(self, stub_mesh_model):
+        au = np.zeros(20, dtype=np.float32)
+        out = stub_mesh_model.predict(au)
+        assert out.shape == (1, 1434)
+
+    def test_predict_pose_padding_is_zero(self, stub_mesh_model):
+        """Wrapper zero-pads 3 pose features. AU + zero pose ≡ explicit
+        23-d call with pose channels set to 0."""
+        au = np.array([0.5, 0.3, 0.0] + [0.0] * 17, dtype=np.float32)
+        out_wrapper = stub_mesh_model.predict(au)
+        x_explicit = np.concatenate([au, np.zeros(3, dtype=np.float32)])
+        out_explicit = (x_explicit[None, :] @ stub_mesh_model._coef
+                        + stub_mesh_model._intercept)
+        np.testing.assert_allclose(out_wrapper, out_explicit, atol=1e-6)
+
+    def test_n_components_is_20(self, stub_mesh_model):
+        assert stub_mesh_model.n_components == 20
+
+    def test_repr_includes_model_name(self, stub_mesh_model):
+        r = repr(stub_mesh_model)
+        assert "au_to_mesh_pls_v2" in r
+        assert "n_components=20" in r
+
+    def test_au_and_pose_columns_preserved(self, stub_mesh_model):
+        assert len(stub_mesh_model.au_columns) == 20
+        assert "AU12" in stub_mesh_model.au_columns
+        assert stub_mesh_model.pose_columns == ["Pitch", "Yaw", "Roll"]
+
+    def test_mean_aligned_mesh_shape(self, stub_mesh_model):
+        assert stub_mesh_model.mean_aligned_mesh.shape == (478, 3)
+
+
+# ---------------------------------------------------------------------
+# predict_face_mesh — axis-major reshape contract
+# ---------------------------------------------------------------------
+
+class TestPredictFaceMesh:
+    def test_default_loads_cached_model(self, stub_mesh_model):
+        out = predict_face_mesh(np.zeros(20))
+        assert out.shape == (478, 3)
+
+    def test_batched_input_returns_3d(self, stub_mesh_model):
+        out = predict_face_mesh(np.zeros((4, 20)))
+        assert out.shape == (4, 478, 3)
+
+    def test_axis_major_reshape_separates_x_y_z(self, stub_mesh_model):
+        """Confirm we slice the flat 1434-d output as ``[x | y | z]``,
+        not the wrong ``(478, 3)`` reshape that would interleave per-vertex.
+
+        The stub fixture explicitly packs three different ranges into the
+        x / y / z slabs of the intercept; the predicted mesh at AU=0 must
+        recover those exact per-axis ranges.
+        """
+        out = predict_face_mesh(np.zeros(20), model=stub_mesh_model)
+        # x slab from intercept was uniform(-7, 7); y was uniform(-9, 8);
+        # z was uniform(-1, 7). With AU=0, predict == intercept exactly,
+        # so slabs reappear column-by-column.
+        np.testing.assert_array_equal(out[:, 0], stub_mesh_model._intercept[:478])
+        np.testing.assert_array_equal(out[:, 1], stub_mesh_model._intercept[478:956])
+        np.testing.assert_array_equal(out[:, 2], stub_mesh_model._intercept[956:])
+
+    def test_au_activation_changes_mesh(self, stub_mesh_model):
+        rest = predict_face_mesh(np.zeros(20), model=stub_mesh_model)
+        au12 = np.zeros(20)
+        au12[stub_mesh_model.au_columns.index("AU12")] = 3.0
+        active = predict_face_mesh(au12, model=stub_mesh_model)
+        assert active.shape == rest.shape
+        # Some non-trivial mesh delta for a moderately strong activation
+        assert np.linalg.norm(active - rest) > 0.0
+
+    def test_rejects_wrong_au_length(self, stub_mesh_model):
+        with pytest.raises(ValueError, match=r"au vector must be length 20"):
+            predict_face_mesh(np.zeros(15), model=stub_mesh_model)
+
+    def test_rejects_non_mesh_model(self, stub_mesh_model):
+        class NotAModel:
+            n_components = 20
+            def predict(self, x): return np.zeros((1, 1434))
+        with pytest.raises(ValueError, match=r"PLSAUMeshModel"):
+            predict_face_mesh(np.zeros(20), model=NotAModel())
+
+
+# ---------------------------------------------------------------------
+# plot_face_mesh — smoke (matplotlib renders without raising)
+# ---------------------------------------------------------------------
+
+class TestPlotFaceMesh:
+    def test_plots_rest_mesh_without_au(self, stub_mesh_model):
+        ax = plot_face_mesh(au=None, model=stub_mesh_model)
+        assert ax is not None
+        # Lines drawn for each canonical contour connection
+        assert len(ax.get_lines()) > 0
+
+    def test_plots_with_au_activation(self, stub_mesh_model):
+        au = np.zeros(20)
+        au[stub_mesh_model.au_columns.index("AU12")] = 2.0
+        ax = plot_face_mesh(au=au, model=stub_mesh_model)
+        assert len(ax.get_lines()) > 0
+
+    def test_rejects_batched_au(self, stub_mesh_model):
+        with pytest.raises(ValueError, match=r"single AU vector"):
+            plot_face_mesh(au=np.zeros((2, 20)), model=stub_mesh_model)
+
+
+# ---------------------------------------------------------------------
+# Real HF Hub fetch — runs once, then hits cache.
+# ---------------------------------------------------------------------
+
+@pytest.mark.network
+class TestRealMeshLoad:
+    def test_load_real_v2_model(self, monkeypatch):
+        # Force a fresh load by clearing the module-level cache
+        monkeypatch.setattr(plt_mod, "_PLS_V2_MESH_MODEL", None)
+        m = load_face_mesh_viz_model()
+        assert isinstance(m, PLSAUMeshModel)
+        assert m.n_components == 20
+        assert m.mean_aligned_mesh.shape == (478, 3)
+        # Sanity: a smile activation should move mesh vertices noticeably
+        au = np.zeros(20)
+        au[m.au_columns.index("AU12")] = 3.0
+        rest = predict_face_mesh(np.zeros(20), model=m)
+        active = predict_face_mesh(au, model=m)
+        per_vertex_disp = np.linalg.norm(active - rest, axis=1)
+        # Lip corner pull should produce a measurable max displacement.
+        # Threshold is intentionally loose: just confirm AU has *some* effect.
+        assert per_vertex_disp.max() > 0.05


### PR DESCRIPTION
## Summary

- New ``PLSAUMeshModel`` + ``predict_face_mesh`` + ``plot_face_mesh`` for opt-in 3D mesh visualization
- 2D 68-pt landmark default from PR #301 is unchanged
- Consumes the v2 AU+pose → 478-vertex PLS model from ``py-feat/au_to_mesh`` on HuggingFace

## Why

The BS→AU pipeline (PRs #300/#302) gives MPDetector a FACS AU output stream, and the 68-pt PLS viz (PR #301) lets users visualize a single face from AU sliders. This PR closes the gap to the full MediaPipe FaceMesh: AU intensities → 478-vertex 3D mesh in a pose-canonical frame, suitable for richer 3D rendering, AU-effect maps, and interactive deformation.

It's **opt-in** — ``plot_face`` still uses the 68-pt PLS by default. ``plot_face_mesh`` is a separate public function for the 3D path. No existing code paths change.

## Implementation

| Symbol | Role |
|---|---|
| ``PLSAUMeshModel`` | wrapper around ``(23 → 1434)`` PLS weights; ``.predict(au)`` returns flat axis-major ``[x \| y \| z]`` mesh coords |
| ``_load_pls_au_to_mesh_v2_from_hub()`` + ``_PLS_V2_MESH_MODEL`` cache | mirrors PR #301 lazy-load pattern |
| ``load_face_mesh_viz_model()`` | public loader |
| ``predict_face_mesh(au, model=None)`` | returns ``(478, 3)`` for ``(20,)`` AU or ``(n, 478, 3)`` for ``(n, 20)``. Splits the flat output axis-major (NOT a per-vertex reshape — that would scramble vertices) |
| ``plot_face_mesh(au=None, ax=None, view_init=(0, -90), …)`` | matplotlib 3D wireframe over ``FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS``; maps data ``(X, Y, Z)`` → mpl ``(X, Z, Y)`` so the face renders upright |

Inference cost is one ``(n, 23) @ (23, 1434)`` matmul — sub-ms even at large batches. HF Hub artifact is ~135 KB.

## Validation

Visual smoke (saved during dev to ``/tmp/face_mesh_smoke.png``): rest, ``AU12=3`` (smile, lip corners up + mouth widened), ``AU04=3`` (brow lower, eyebrows pulled in/down) all render with correct topology.

## Test plan

- [x] 17 new tests in ``test_face_mesh_viz.py``
  - 16 offline (stubbed module cache): wrapper shape contract, pose-zero padding, axis-major reshape recovery (encode distinct ranges per slab and verify per-axis recovery), AU-activation produces a non-zero mesh delta, error paths, plot smoke
  - 1 network: real HF Hub fetch, real AU12 displacement
- [x] All existing offline tests pass

## Backward compatibility

Additive — new public symbols only. ``plot_face`` / ``predict`` / ``load_viz_model`` unchanged.

## Related work

PR5 of the planned sequence:
- PR #300: BS→AU PLS (merged)
- PR #301: 68-pt landmarks default swap (merged)
- PR #302: MPDetector AU columns (merged)
- PR #303: unified dlib-68 accessor (merged)
- **PR5 (this)**: AU → 478-pt mesh visualization
- PR6: 68 → 478 mesh bridge
- PR7: Plotting cleanup + Plotly backend