### PR TITLE
feat(plotting): dlib-68 → MP-478 mesh bridge (PR6)

### DIFF
--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1538,6 +1538,7 @@ def predict_face_mesh(au, model=None):
 
 def plot_face_mesh(
     au=None,
+    mesh=None,
     model=None,
     ax=None,
     color="black",
@@ -1548,8 +1549,13 @@ def plot_face_mesh(
     """3D wireframe of the predicted face mesh. Opt-in alternative to ``plot_face``.
 
     Renders the canonical MediaPipe contours (lips + eyes + eyebrows + face
-    oval) from the predicted 478-vertex mesh. For a quick reference plot,
-    leave ``au=None`` to draw the population-mean rest mesh.
+    oval) from a 478-vertex mesh. The mesh source is selected by what the
+    caller passes:
+
+    - ``mesh`` given: draw that mesh directly (e.g., output of
+      ``predict_mesh_from_dlib68`` for a Detector Fex).
+    - ``au`` given: predict via the AU→mesh PLS model (PR #304).
+    - neither: draw the population-mean rest mesh.
 
     Coordinate frame: the trained mesh uses standard math convention with
     ``+X`` lateral, ``+Y`` up (forehead at ~+8, chin at ~-8), ``+Z`` out of
@@ -1559,8 +1565,9 @@ def plot_face_mesh(
 
     Args:
         au: AU intensity vector ``(20,)`` in ``AU_LANDMARK_MAP['Feat']`` order.
-            ``None`` plots the rest mesh.
-        model: optional ``PLSAUMeshModel``; defaults to the cached v2 model.
+        mesh: precomputed ``(478, 3)`` mesh array, in the canonical frame.
+        model: optional ``PLSAUMeshModel`` for the ``au`` path; defaults to
+            the cached v2 model.
         ax: optional matplotlib 3D axis. If ``None``, a new figure is created.
         color, linewidth, alpha: line styling.
         view_init: ``(elev, azim)`` matplotlib view angles. Default frames
@@ -1572,7 +1579,17 @@ def plot_face_mesh(
     from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3d projection)
     from feat.utils.mp_plotting import FaceLandmarksConnections
 
-    if au is None:
+    if mesh is not None and au is not None:
+        raise ValueError("pass either `au` or `mesh`, not both")
+
+    if mesh is not None:
+        verts = np.asarray(mesh, dtype=np.float32)
+        if verts.shape != (478, 3):
+            raise ValueError(
+                f"mesh must have shape (478, 3); got {verts.shape}. "
+                "For batched predictions, plot one face at a time."
+            )
+    elif au is None:
         if model is None:
             model = load_face_mesh_viz_model()
         verts = model.mean_aligned_mesh
@@ -1616,6 +1633,240 @@ def plot_face_mesh(
     ax.view_init(elev=view_init[0], azim=view_init[1])
     ax.set_axis_off()
     return ax
+
+
+# ---------------------------------------------------------------------
+# 68-pt dlib landmarks → 478-vertex MediaPipe FaceMesh bridge.
+# Lets users with a Detector Fex (mobilefacenet 68-pt) reconstruct an
+# approximate MP mesh, opening up plot_face_mesh + downstream 3D consumers
+# without a separate MPDetector pass. PCA-bottleneck linear regression
+# trained on 340K paired (dlib-68, MP-478) frames; OOS R² ≈ 0.48.
+# See https://huggingface.co/py-feat/landmarks68_to_mesh478.
+# ---------------------------------------------------------------------
+
+
+def _procrustes_align_2d_batched(coords, anchor_idx, ref_anchors):
+    """Batched 2D Umeyama similarity alignment.
+
+    Aligns each face's full landmark set so that its anchor subset best
+    matches the reference anchors (in least-squares sense, allowing
+    rotation + isotropic scale + translation). Mirrors the helper used at
+    training time so inference operates in the same canonical frame.
+
+    Args:
+        coords: ``(n, 68, 2)`` raw 2-D landmarks per face.
+        anchor_idx: ``(k,)`` int indices of stable anchors (e.g., the 8
+            saved with the model: nose bridge 27-30 + canthi 36/39/42/45).
+        ref_anchors: ``(k, 2)`` reference anchor positions.
+
+    Returns:
+        ``(n, 68, 2)`` aligned landmarks in the reference frame.
+    """
+    coords = np.asarray(coords, dtype=np.float32)
+    if coords.ndim != 3 or coords.shape[1:] != (68, 2):
+        raise ValueError(
+            f"coords must have shape (n, 68, 2); got {coords.shape}"
+        )
+    N = coords.shape[0]
+    P = coords[:, anchor_idx]  # (N, k, 2)
+    P_mean = P.mean(axis=1, keepdims=True)
+    Q_mean = ref_anchors.mean(axis=0)
+    P_c = P - P_mean
+    Q_c = ref_anchors - Q_mean
+    H = np.einsum("ki,nkj->nij", Q_c.astype(np.float64), P_c.astype(np.float64))
+    U, S, Vt = np.linalg.svd(H)
+    UVt = U @ Vt
+    det = np.linalg.det(UVt)
+    d = np.where(det < 0, -1.0, 1.0)
+    D = np.zeros((N, 2, 2), dtype=np.float64)
+    D[:, 0, 0] = 1.0
+    D[:, 1, 1] = d
+    R = U @ D @ Vt
+    var_P = (P_c.astype(np.float64) ** 2).sum(axis=(1, 2))
+    s_num = (S * np.stack([np.ones(N), d], axis=1)).sum(axis=1)
+    s = s_num / np.maximum(var_P, 1e-12)
+    P_mean_sq = P_mean.squeeze(1).astype(np.float64)
+    Rp = np.einsum("nij,nj->ni", R, P_mean_sq)
+    t = Q_mean.astype(np.float64)[None] - s[:, None] * Rp
+    coords_64 = coords.astype(np.float64)
+    aligned = (
+        s[:, None, None] * np.einsum("nvi,nji->nvj", coords_64, R)
+        + t[:, None, :]
+    )
+    return aligned.astype(np.float32)
+
+
+class PCALandmarks68ToMeshModel:
+    """Wrapper around the v2 dlib-68 → MP-478 PCA-bottleneck bridge weights.
+
+    Inference takes Procrustes-aligned 68-pt landmarks (axis-major flat
+    ``[x_0..x_67 | y_0..y_67]``, 136-d) and emits the 478-vertex 3D mesh
+    flattened to 1434-d in the same axis-major layout as the AU→mesh model
+    (PR #304). Use ``predict_mesh_from_dlib68()`` for the convenient end-to-end
+    path that handles raw-landmark alignment + reshape.
+
+    Loaded by ``load_landmarks68_to_mesh478_model()``. Underlying weights live
+    in the ``py-feat/landmarks68_to_mesh478`` HF Hub repo. OOS R² ≈ 0.48.
+    """
+
+    def __init__(
+        self,
+        coef,
+        intercept,
+        input_columns,
+        anchor_indices_dlib68,
+        reference_dlib_anchors,
+        mean_aligned_dlib_landmarks,
+        mean_predicted_mesh,
+        model_name="landmarks68_to_mesh478_pca_v2",
+    ):
+        # coef shape: (136, 1434); deployed weights with PCA absorbed
+        self._coef = np.asarray(coef, dtype=np.float32)
+        self._intercept = np.asarray(intercept, dtype=np.float32)
+        self.input_columns = list(input_columns)
+        self.anchor_indices_dlib68 = np.asarray(anchor_indices_dlib68, dtype=np.int64)
+        self.reference_dlib_anchors = np.asarray(reference_dlib_anchors, dtype=np.float32)
+        self.mean_aligned_dlib_landmarks = np.asarray(
+            mean_aligned_dlib_landmarks, dtype=np.float32
+        )
+        self.mean_predicted_mesh = np.asarray(mean_predicted_mesh, dtype=np.float32)
+        self.model_name_ = model_name
+
+    def predict(self, aligned_landmarks_136):
+        """Predict (n, 1434) flat axis-major mesh from (n, 136) aligned landmarks.
+
+        Inputs must already be Procrustes-aligned to the model's reference
+        anchors. Use ``predict_mesh_from_dlib68()`` for raw-landmark inputs
+        (it handles alignment + reshape).
+        """
+        x = np.asarray(aligned_landmarks_136, dtype=np.float32)
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
+        if x.shape[1] != self._coef.shape[0]:
+            raise ValueError(
+                f"input must have {self._coef.shape[0]} columns "
+                "(axis-major aligned [x_0..x_67 | y_0..y_67]); "
+                f"got {x.shape[1]}."
+            )
+        return x @ self._coef + self._intercept
+
+    def __repr__(self):
+        return (
+            f"PCALandmarks68ToMeshModel(model_name='{self.model_name_}', "
+            f"input_dim={self._coef.shape[0]}, "
+            f"output_shape=(n_samples, 478, 3))"
+        )
+
+
+_LM68_TO_MESH478_MODEL = None
+
+
+def _load_landmarks68_to_mesh478_v2_from_hub(verbose=False):
+    """Download (cached) and wrap the v2 68→478 PCA-bottleneck NPZ from HF Hub."""
+    global _LM68_TO_MESH478_MODEL
+    if _LM68_TO_MESH478_MODEL is not None:
+        return _LM68_TO_MESH478_MODEL
+
+    if verbose:
+        print("Loading v2 PCA dlib-68 → MP-478 model from HuggingFace Hub")
+    path = hf_hub_download(
+        repo_id="py-feat/landmarks68_to_mesh478",
+        filename="landmarks68_to_mesh478_pca_v2.npz",
+        cache_dir=get_resource_path(),
+    )
+    z = np.load(path, allow_pickle=False)
+    input_columns = [str(s) for s in z["input_columns"]]
+    # Guard against silent layout drift: the bridge expects axis-major
+    # `lm_x_0..lm_x_67, lm_y_0..lm_y_67`. A future re-trained npz with a
+    # different convention (e.g., interleaved per-vertex) would silently
+    # produce garbage.
+    expected = [f"lm_x_{i}" for i in range(68)] + [f"lm_y_{i}" for i in range(68)]
+    if input_columns != expected:
+        raise RuntimeError(
+            "landmarks68_to_mesh478 input_columns drifted from canonical "
+            "axis-major lm_x / lm_y layout. Re-train or update the loader."
+        )
+    _LM68_TO_MESH478_MODEL = PCALandmarks68ToMeshModel(
+        coef=z["coef"],
+        intercept=z["intercept"],
+        input_columns=input_columns,
+        anchor_indices_dlib68=z["anchor_indices_dlib68"],
+        reference_dlib_anchors=z["reference_dlib_anchors"],
+        mean_aligned_dlib_landmarks=z["mean_aligned_dlib_landmarks"],
+        mean_predicted_mesh=z["mean_predicted_mesh"],
+        model_name="landmarks68_to_mesh478_pca_v2",
+    )
+    return _LM68_TO_MESH478_MODEL
+
+
+def load_landmarks68_to_mesh478_model(verbose=False):
+    """Load the dlib-68 → MP-478 PCA-bottleneck bridge model.
+
+    Use ``predict_mesh_from_dlib68()`` for the convenient end-to-end path
+    that aligns raw landmarks + predicts + reshapes in one call.
+
+    Args:
+        verbose: print a status line when first downloading.
+
+    Returns:
+        PCALandmarks68ToMeshModel
+    """
+    return _load_landmarks68_to_mesh478_v2_from_hub(verbose=verbose)
+
+
+def predict_mesh_from_dlib68(landmarks_68, model=None):
+    """Reconstruct a 478-vertex MP mesh from raw 68-pt dlib landmarks.
+
+    Bridges Detector output (mobilefacenet 68-pt landmarks in image-space
+    pixels) to the MediaPipe FaceMesh frame, so users with a Detector Fex
+    can feed ``plot_face_mesh()`` or other 3D consumers without running
+    MPDetector.
+
+    Steps internally:
+        1. Procrustes-align the raw landmarks to the saved reference anchors
+           (8 stable upper-face points: nose bridge + canthi).
+        2. Flatten axis-major and apply the (136 → 1434) PCA-bottleneck weights.
+        3. Reshape the flat output to ``(478, 3)``.
+
+    Args:
+        landmarks_68: ``(68, 2)`` for a single face or ``(n, 68, 2)`` for a
+            batch. In image-space pixels (e.g., from
+            ``Fex.landmarks_dlib68_xy``).
+        model: optional ``PCALandmarks68ToMeshModel``; defaults to the cached
+            v2 model.
+
+    Returns:
+        Predicted mesh in pose-canonical-frame coordinates (GPA-aligned cm,
+        not image pixels). Shape ``(478, 3)`` for a 2-D input,
+        ``(n, 478, 3)`` for a 3-D batch.
+    """
+    if model is None:
+        model = load_landmarks68_to_mesh478_model()
+    if not isinstance(model, PCALandmarks68ToMeshModel):
+        raise ValueError(
+            "model must be a PCALandmarks68ToMeshModel "
+            "(returned by feat.plotting.load_landmarks68_to_mesh478_model())"
+        )
+    arr = np.asarray(landmarks_68, dtype=np.float32)
+    is_single = arr.ndim == 2
+    if arr.ndim == 2:
+        arr = arr[None, ...]
+    if arr.ndim != 3 or arr.shape[1:] != (68, 2):
+        raise ValueError(
+            f"landmarks_68 must have shape (68, 2) or (n, 68, 2); got {arr.shape}"
+        )
+
+    aligned = _procrustes_align_2d_batched(
+        arr, model.anchor_indices_dlib68, model.reference_dlib_anchors,
+    )
+    # Axis-major flat input: [x_0..x_67 | y_0..y_67]
+    x_flat = np.hstack([aligned[:, :, 0], aligned[:, :, 1]]).astype(np.float32)
+    flat = model.predict(x_flat)  # (n, 1434), axis-major [x | y | z]
+    xs = flat[:, :478]
+    ys = flat[:, 478:956]
+    zs = flat[:, 956:]
+    mesh = np.stack([xs, ys, zs], axis=-1)  # (n, 478, 3)
+    return mesh[0] if is_single else mesh
 
 
 def load_viz_model(

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1538,13 +1538,14 @@ def predict_face_mesh(au, model=None):
 
 def plot_face_mesh(
     au=None,
-    mesh=None,
     model=None,
     ax=None,
     color="black",
     linewidth=0.6,
     alpha=0.9,
     view_init=(0, -90),
+    *,
+    mesh=None,
 ):
     """3D wireframe of the predicted face mesh. Opt-in alternative to ``plot_face``.
 

--- a/feat/tests/test_landmarks68_to_mesh478.py
+++ b/feat/tests/test_landmarks68_to_mesh478.py
@@ -1,0 +1,284 @@
+"""Tests for the dlib-68 → MP-478 mesh bridge (PR6).
+
+Covers ``PCALandmarks68ToMeshModel``, ``predict_mesh_from_dlib68``, the
+private ``_procrustes_align_2d_batched`` helper, the ``mesh=`` extension to
+``plot_face_mesh``, and the column-order drift guard. Offline tests use
+synthetic stub models; one ``@pytest.mark.network`` test loads the real npz.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use("Agg")  # headless
+
+from feat import plotting as plt_mod
+from feat.plotting import (
+    PCALandmarks68ToMeshModel,
+    _procrustes_align_2d_batched,
+    load_landmarks68_to_mesh478_model,
+    plot_face_mesh,
+    predict_mesh_from_dlib68,
+)
+
+
+# ---------------------------------------------------------------------
+# Stub fixture — synthetic model whose intercept slabs encode distinct
+# per-axis ranges so axis-major reshape can be pinned end-to-end.
+# ---------------------------------------------------------------------
+
+@pytest.fixture
+def stub_bridge_model(monkeypatch):
+    rng = np.random.default_rng(0)
+    coef = rng.standard_normal((136, 1434)).astype(np.float32) * 0.001
+    intercept = np.empty(1434, dtype=np.float32)
+    intercept[:478] = rng.uniform(-7, 7, 478)            # x slab
+    intercept[478:956] = rng.uniform(-9, 8, 478)         # y slab
+    intercept[956:] = rng.uniform(-1, 7, 478)            # z slab
+    input_columns = ([f"lm_x_{i}" for i in range(68)]
+                     + [f"lm_y_{i}" for i in range(68)])
+    anchor_indices = np.array([27, 28, 29, 30, 36, 39, 42, 45], dtype=np.int64)
+    # Reference: a plausible canonical dlib face shape.
+    ref_anchors = np.array([
+        [320.0, 250.0],   # 27: nose root top
+        [322.0, 266.0],   # 28
+        [323.0, 281.0],   # 29
+        [324.0, 295.0],   # 30: nose tip
+        [270.0, 260.0],   # 36: outer right canthus
+        [299.0, 258.0],   # 39: inner right canthus
+        [343.0, 254.0],   # 42: inner left canthus
+        [372.0, 250.0],   # 45: outer left canthus
+    ], dtype=np.float32)
+    mean_dlib = rng.uniform(200, 400, (68, 2)).astype(np.float32)
+    mean_mesh = np.column_stack([
+        intercept[:478], intercept[478:956], intercept[956:],
+    ])
+    model = PCALandmarks68ToMeshModel(
+        coef=coef, intercept=intercept, input_columns=input_columns,
+        anchor_indices_dlib68=anchor_indices,
+        reference_dlib_anchors=ref_anchors,
+        mean_aligned_dlib_landmarks=mean_dlib,
+        mean_predicted_mesh=mean_mesh,
+    )
+    monkeypatch.setattr(plt_mod, "_LM68_TO_MESH478_MODEL", model)
+    return model
+
+
+# ---------------------------------------------------------------------
+# _procrustes_align_2d_batched
+# ---------------------------------------------------------------------
+
+class TestProcrustes2D:
+    def test_identity_when_anchors_already_match(self, stub_bridge_model):
+        """If a face's anchors already equal the reference, alignment is a no-op."""
+        landmarks = stub_bridge_model.mean_aligned_dlib_landmarks.copy()
+        # Place the reference anchors at the canonical positions
+        landmarks[stub_bridge_model.anchor_indices_dlib68] = (
+            stub_bridge_model.reference_dlib_anchors
+        )
+        aligned = _procrustes_align_2d_batched(
+            landmarks[None],
+            stub_bridge_model.anchor_indices_dlib68,
+            stub_bridge_model.reference_dlib_anchors,
+        )
+        np.testing.assert_allclose(
+            aligned[0, stub_bridge_model.anchor_indices_dlib68],
+            stub_bridge_model.reference_dlib_anchors,
+            atol=1e-3,
+        )
+
+    def test_recovers_reference_after_rotation_scale(self, stub_bridge_model):
+        """Apply a rotation + scale + translation to a face that already
+        matches the reference; alignment should invert it."""
+        landmarks = np.zeros((68, 2), dtype=np.float32)
+        landmarks[stub_bridge_model.anchor_indices_dlib68] = (
+            stub_bridge_model.reference_dlib_anchors
+        )
+        # Apply a known similarity: rotate by 30°, scale 1.5x, translate by (50, -20)
+        theta = np.deg2rad(30.0)
+        R = np.array([[np.cos(theta), -np.sin(theta)],
+                      [np.sin(theta),  np.cos(theta)]], dtype=np.float32)
+        s = 1.5
+        t = np.array([50.0, -20.0], dtype=np.float32)
+        transformed = (s * landmarks @ R.T + t).astype(np.float32)
+        aligned = _procrustes_align_2d_batched(
+            transformed[None],
+            stub_bridge_model.anchor_indices_dlib68,
+            stub_bridge_model.reference_dlib_anchors,
+        )
+        np.testing.assert_allclose(
+            aligned[0, stub_bridge_model.anchor_indices_dlib68],
+            stub_bridge_model.reference_dlib_anchors,
+            atol=1e-2,
+        )
+
+    def test_rejects_wrong_shape(self, stub_bridge_model):
+        with pytest.raises(ValueError, match=r"\(n, 68, 2\)"):
+            _procrustes_align_2d_batched(
+                np.zeros((10, 2), dtype=np.float32),
+                stub_bridge_model.anchor_indices_dlib68,
+                stub_bridge_model.reference_dlib_anchors,
+            )
+
+
+# ---------------------------------------------------------------------
+# PCALandmarks68ToMeshModel
+# ---------------------------------------------------------------------
+
+class TestPCALandmarks68ToMeshModel:
+    def test_predict_2d_batch_returns_flat(self, stub_bridge_model):
+        x = np.zeros((3, 136), dtype=np.float32)
+        out = stub_bridge_model.predict(x)
+        assert out.shape == (3, 1434)
+
+    def test_predict_1d_returns_2d_one_row(self, stub_bridge_model):
+        x = np.zeros(136, dtype=np.float32)
+        out = stub_bridge_model.predict(x)
+        assert out.shape == (1, 1434)
+
+    def test_predict_rejects_wrong_input_width(self, stub_bridge_model):
+        with pytest.raises(ValueError, match=r"must have 136 columns"):
+            stub_bridge_model.predict(np.zeros((4, 130), dtype=np.float32))
+        with pytest.raises(ValueError, match=r"must have 136 columns"):
+            stub_bridge_model.predict(np.zeros(130, dtype=np.float32))
+
+    def test_repr_includes_model_name(self, stub_bridge_model):
+        r = repr(stub_bridge_model)
+        assert "landmarks68_to_mesh478_pca_v2" in r
+        assert "input_dim=136" in r
+
+
+# ---------------------------------------------------------------------
+# predict_mesh_from_dlib68 — end-to-end with axis-major reshape pinning
+# ---------------------------------------------------------------------
+
+class TestPredictMeshFromDlib68:
+    def test_single_face_returns_478_3(self, stub_bridge_model):
+        landmarks = stub_bridge_model.mean_aligned_dlib_landmarks
+        mesh = predict_mesh_from_dlib68(landmarks)
+        assert mesh.shape == (478, 3)
+
+    def test_batched_returns_n_478_3(self, stub_bridge_model):
+        batch = np.stack([stub_bridge_model.mean_aligned_dlib_landmarks] * 4)
+        mesh = predict_mesh_from_dlib68(batch)
+        assert mesh.shape == (4, 478, 3)
+
+    def test_axis_major_reshape_recovers_per_axis_ranges(self, stub_bridge_model):
+        """Pin axis-major reshape end-to-end: with coef set to zero, predict
+        is exactly the intercept regardless of input. Each intercept slab's
+        distinct range must reappear on the matching axis of the (478, 3)
+        output. Catches a future swap to per-vertex (478, 3) reshape that
+        would scramble vertex ordering.
+        """
+        # Use the existing stub but null out the coef so the regression
+        # contribution drops to zero — the output IS the intercept slabs.
+        zero_coef_model = PCALandmarks68ToMeshModel(
+            coef=np.zeros_like(stub_bridge_model._coef),
+            intercept=stub_bridge_model._intercept,
+            input_columns=stub_bridge_model.input_columns,
+            anchor_indices_dlib68=stub_bridge_model.anchor_indices_dlib68,
+            reference_dlib_anchors=stub_bridge_model.reference_dlib_anchors,
+            mean_aligned_dlib_landmarks=stub_bridge_model.mean_aligned_dlib_landmarks,
+            mean_predicted_mesh=stub_bridge_model.mean_predicted_mesh,
+        )
+        mesh = predict_mesh_from_dlib68(
+            stub_bridge_model.mean_aligned_dlib_landmarks, model=zero_coef_model,
+        )
+        np.testing.assert_array_equal(mesh[:, 0], zero_coef_model._intercept[:478])
+        np.testing.assert_array_equal(mesh[:, 1], zero_coef_model._intercept[478:956])
+        np.testing.assert_array_equal(mesh[:, 2], zero_coef_model._intercept[956:])
+
+    def test_rejects_wrong_landmark_shape(self, stub_bridge_model):
+        with pytest.raises(ValueError, match=r"\(68, 2\) or \(n, 68, 2\)"):
+            predict_mesh_from_dlib68(np.zeros((50, 2)), model=stub_bridge_model)
+
+    def test_rejects_non_bridge_model(self, stub_bridge_model):
+        class NotAModel:
+            def predict(self, x): return np.zeros((1, 1434))
+        with pytest.raises(ValueError, match=r"PCALandmarks68ToMeshModel"):
+            predict_mesh_from_dlib68(
+                np.zeros((68, 2)), model=NotAModel(),
+            )
+
+
+# ---------------------------------------------------------------------
+# plot_face_mesh — new mesh= path
+# ---------------------------------------------------------------------
+
+class TestPlotFaceMeshWithMesh:
+    def test_accepts_precomputed_mesh(self, stub_bridge_model):
+        mesh = stub_bridge_model.mean_predicted_mesh
+        ax = plot_face_mesh(mesh=mesh)
+        assert ax is not None
+        assert len(ax.get_lines()) > 0
+
+    def test_rejects_both_au_and_mesh(self, stub_bridge_model):
+        mesh = stub_bridge_model.mean_predicted_mesh
+        with pytest.raises(ValueError, match=r"either `au` or `mesh`"):
+            plot_face_mesh(au=np.zeros(20), mesh=mesh)
+
+    def test_rejects_wrong_mesh_shape(self):
+        with pytest.raises(ValueError, match=r"shape \(478, 3\)"):
+            plot_face_mesh(mesh=np.zeros((100, 3)))
+
+
+# ---------------------------------------------------------------------
+# Drift guard
+# ---------------------------------------------------------------------
+
+class TestInputColumnDriftGuard:
+    def test_drift_raises_at_load(self, monkeypatch, tmp_path):
+        """If a future re-trained npz uses a non-axis-major layout (e.g.,
+        interleaved per-vertex), the loader must refuse rather than silently
+        producing garbage meshes."""
+        # Build a fake npz with interleaved column names instead of axis-major
+        bad_path = tmp_path / "lm68_to_mesh_bad.npz"
+        bad_columns = []
+        for i in range(68):
+            bad_columns.extend([f"lm_x_{i}", f"lm_y_{i}"])  # interleaved
+        np.savez(
+            bad_path,
+            coef=np.zeros((136, 1434), dtype=np.float32),
+            intercept=np.zeros(1434, dtype=np.float32),
+            input_columns=np.array(bad_columns),
+            anchor_indices_dlib68=np.array([27, 28, 29, 30, 36, 39, 42, 45], dtype=np.int32),
+            reference_dlib_anchors=np.zeros((8, 2), dtype=np.float32),
+            mean_aligned_dlib_landmarks=np.zeros((68, 2), dtype=np.float32),
+            mean_predicted_mesh=np.zeros((478, 3), dtype=np.float32),
+        )
+
+        monkeypatch.setattr(plt_mod, "_LM68_TO_MESH478_MODEL", None)
+        monkeypatch.setattr(plt_mod, "hf_hub_download",
+                            lambda **kwargs: str(bad_path))
+
+        with pytest.raises(RuntimeError, match=r"input_columns drifted"):
+            plt_mod._load_landmarks68_to_mesh478_v2_from_hub()
+
+
+# ---------------------------------------------------------------------
+# Real HF Hub fetch — runs once, then hits cache.
+# ---------------------------------------------------------------------
+
+@pytest.mark.network
+class TestRealBridgeLoad:
+    def test_load_real_v2_model(self, monkeypatch):
+        monkeypatch.setattr(plt_mod, "_LM68_TO_MESH478_MODEL", None)
+        m = load_landmarks68_to_mesh478_model()
+        assert isinstance(m, PCALandmarks68ToMeshModel)
+        assert m._coef.shape == (136, 1434)
+        assert m.mean_aligned_dlib_landmarks.shape == (68, 2)
+        assert m.mean_predicted_mesh.shape == (478, 3)
+
+    def test_mean_landmarks_reconstruct_close_to_mean_mesh(self, monkeypatch):
+        """Feeding the saved mean dlib landmarks back through the bridge
+        should approximately reproduce the saved mean predicted mesh.
+        """
+        monkeypatch.setattr(plt_mod, "_LM68_TO_MESH478_MODEL", None)
+        m = load_landmarks68_to_mesh478_model()
+        mesh = predict_mesh_from_dlib68(m.mean_aligned_dlib_landmarks, model=m)
+        # Threshold is loose: alignment of the mean landmarks vs. the
+        # population mean isn't a perfect round-trip, but should be within
+        # 1 cm per axis (mesh is in cm units).
+        max_diff = float(np.abs(mesh - m.mean_predicted_mesh).max())
+        assert max_diff < 1.0, f"Reconstruction diff too high: {max_diff:.3f} cm"

--- a/feat/tests/test_landmarks68_to_mesh478.py
+++ b/feat/tests/test_landmarks68_to_mesh478.py
@@ -189,6 +189,13 @@ class TestPredictMeshFromDlib68:
         np.testing.assert_array_equal(mesh[:, 1], zero_coef_model._intercept[478:956])
         np.testing.assert_array_equal(mesh[:, 2], zero_coef_model._intercept[956:])
 
+    def test_empty_batch_passthrough(self, stub_bridge_model):
+        """A zero-row batch (e.g. when no faces detected upstream) should
+        produce an empty (0, 478, 3) result without raising."""
+        empty = np.zeros((0, 68, 2), dtype=np.float32)
+        out = predict_mesh_from_dlib68(empty, model=stub_bridge_model)
+        assert out.shape == (0, 478, 3)
+
     def test_rejects_wrong_landmark_shape(self, stub_bridge_model):
         with pytest.raises(ValueError, match=r"\(68, 2\) or \(n, 68, 2\)"):
             predict_mesh_from_dlib68(np.zeros((50, 2)), model=stub_bridge_model)


### PR DESCRIPTION
## Summary

- New ``predict_mesh_from_dlib68(landmarks)`` reconstructs an approximate 478-vertex MediaPipe FaceMesh from 68-pt dlib landmarks (Detector output)
- ``plot_face_mesh`` now accepts a precomputed ``mesh=`` arg in addition to ``au=`` so either AU- or landmark-derived meshes go through the same renderer
- Consumes the v2 PCA-bottleneck model from ``py-feat/landmarks68_to_mesh478`` on HF Hub

## Why

PR #304 added 3D mesh viz from AU intensities. But py-feat's standard ``Detector`` pipeline outputs 68-pt dlib landmarks, not the 478-vertex MP mesh — so users with a Detector Fex couldn't access ``plot_face_mesh`` or any 3D-mesh consumer without running a separate ``MPDetector`` pass. This PR closes that gap with a fast linear bridge.

OOS R² ≈ 0.48 (variance-weighted across 1434 dims, 5-fold GroupKFold by video, 340K paired frames). Substantially better than AU→mesh (0.244) because dlib landmarks share rich spatial information with the MP mesh that 20 AU intensities can't encode.

## Implementation

| Symbol | Role |
|---|---|
| ``_procrustes_align_2d_batched`` | private 2D Umeyama similarity helper; aligns raw landmarks to the model's saved 8-anchor reference (nose bridge 27-30 + canthi 36/39/42/45) |
| ``PCALandmarks68ToMeshModel`` | wrapper around (136 → 1434) v2 PCA-bottleneck weights; ``.predict()`` returns flat axis-major ``[x \| y \| z]`` mesh coords |
| ``_load_landmarks68_to_mesh478_v2_from_hub`` + ``_LM68_TO_MESH478_MODEL`` cache | fetch + cache pattern mirrors PR #304 |
| ``load_landmarks68_to_mesh478_model()`` | public loader |
| ``predict_mesh_from_dlib68(landmarks_68, model=None)`` | end-to-end: align raw landmarks, apply bridge, axis-major reshape; ``(68, 2)`` or ``(n, 68, 2)`` input |
| ``plot_face_mesh(mesh=...)`` extension | renders a precomputed mesh; mutually exclusive with ``au=`` |

Inference cost: one similarity-transform SVD (~8-anchor) + one (n, 136) @ (136, 1434) matmul per face. Sub-ms even at large batches.

## Drift guard

The loader refuses to cache a model whose ``input_columns`` don't match the canonical axis-major layout ``[lm_x_0..lm_x_67, lm_y_0..lm_y_67]``. A future re-trained npz with a shuffled or interleaved layout would silently produce garbage meshes without this check.

## Validation

- Smoke (saved during dev): feed the saved ``mean_aligned_dlib_landmarks`` back through ``predict_mesh_from_dlib68`` and compare to the saved ``mean_predicted_mesh``. Max diff = 0.44 cm (round-trip not exact due to alignment).
- Side-by-side render: dlib-68-derived mesh vs AU-mesh rest reference. Topologies render identically through ``plot_face_mesh``.

## Test plan

- [x] 18 new tests in ``test_landmarks68_to_mesh478.py``
  - Procrustes 2D: identity case, known similarity recovery (rotate 30° + scale 1.5x + translate), shape rejection
  - Wrapper shape contract + wrong-width rejection
  - End-to-end shape (single, batched)
  - Axis-major reshape pin: zero-coef model so output is exactly the intercept slabs; verifies x/y/z slabs land on the right axis
  - ``plot_face_mesh(mesh=)``: accepts (478, 3), rejects au+mesh together, rejects wrong shape
  - Drift guard: synthesizes a fake interleaved-column npz, monkeypatches ``hf_hub_download``, asserts RuntimeError
  - Network: real load + round-trip ≤ 1 cm
- [x] All 20 PR #304 tests still pass with the new ``mesh=`` extension

## Backward compatibility

Additive — new public symbols + a new optional kwarg on ``plot_face_mesh``. Existing ``predict_face_mesh`` / ``load_face_mesh_viz_model`` paths unchanged.

## Related work

PR6 of the planned sequence:
- PR #300: BS→AU PLS (merged)
- PR #301: 68-pt landmarks default swap (merged)
- PR #302: MPDetector AU columns (merged)
- PR #303: unified dlib-68 accessor (merged)
- PR #304: AU → 478-pt mesh viz (merged)
- **PR6 (this)**: 68 → 478 mesh bridge
- PR7: Plotting cleanup + Plotly backend