### PR TITLE
refactor: hoist procrustes_align_2d_batched into feat.utils.image_operations

### DIFF
--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -12,7 +12,11 @@ from sklearn import __version__ as skversion
 import matplotlib.pyplot as plt
 from feat.pretrained import AU_LANDMARK_MAP
 from feat.utils.io import get_resource_path, download_url
-from feat.utils.image_operations import align_face, mask_image
+from feat.utils.image_operations import (
+    align_face,
+    mask_image,
+    procrustes_align_2d_batched,
+)
 from feat.utils import flatten_list
 from huggingface_hub import hf_hub_download
 from math import sin, cos
@@ -1646,57 +1650,6 @@ def plot_face_mesh(
 # ---------------------------------------------------------------------
 
 
-def _procrustes_align_2d_batched(coords, anchor_idx, ref_anchors):
-    """Batched 2D Umeyama similarity alignment.
-
-    Aligns each face's full landmark set so that its anchor subset best
-    matches the reference anchors (in least-squares sense, allowing
-    rotation + isotropic scale + translation). Mirrors the helper used at
-    training time so inference operates in the same canonical frame.
-
-    Args:
-        coords: ``(n, 68, 2)`` raw 2-D landmarks per face.
-        anchor_idx: ``(k,)`` int indices of stable anchors (e.g., the 8
-            saved with the model: nose bridge 27-30 + canthi 36/39/42/45).
-        ref_anchors: ``(k, 2)`` reference anchor positions.
-
-    Returns:
-        ``(n, 68, 2)`` aligned landmarks in the reference frame.
-    """
-    coords = np.asarray(coords, dtype=np.float32)
-    if coords.ndim != 3 or coords.shape[1:] != (68, 2):
-        raise ValueError(
-            f"coords must have shape (n, 68, 2); got {coords.shape}"
-        )
-    N = coords.shape[0]
-    P = coords[:, anchor_idx]  # (N, k, 2)
-    P_mean = P.mean(axis=1, keepdims=True)
-    Q_mean = ref_anchors.mean(axis=0)
-    P_c = P - P_mean
-    Q_c = ref_anchors - Q_mean
-    H = np.einsum("ki,nkj->nij", Q_c.astype(np.float64), P_c.astype(np.float64))
-    U, S, Vt = np.linalg.svd(H)
-    UVt = U @ Vt
-    det = np.linalg.det(UVt)
-    d = np.where(det < 0, -1.0, 1.0)
-    D = np.zeros((N, 2, 2), dtype=np.float64)
-    D[:, 0, 0] = 1.0
-    D[:, 1, 1] = d
-    R = U @ D @ Vt
-    var_P = (P_c.astype(np.float64) ** 2).sum(axis=(1, 2))
-    s_num = (S * np.stack([np.ones(N), d], axis=1)).sum(axis=1)
-    s = s_num / np.maximum(var_P, 1e-12)
-    P_mean_sq = P_mean.squeeze(1).astype(np.float64)
-    Rp = np.einsum("nij,nj->ni", R, P_mean_sq)
-    t = Q_mean.astype(np.float64)[None] - s[:, None] * Rp
-    coords_64 = coords.astype(np.float64)
-    aligned = (
-        s[:, None, None] * np.einsum("nvi,nji->nvj", coords_64, R)
-        + t[:, None, :]
-    )
-    return aligned.astype(np.float32)
-
-
 class PCALandmarks68ToMeshModel:
     """Wrapper around the v2 dlib-68 → MP-478 PCA-bottleneck bridge weights.
 
@@ -1857,7 +1810,7 @@ def predict_mesh_from_dlib68(landmarks_68, model=None):
             f"landmarks_68 must have shape (68, 2) or (n, 68, 2); got {arr.shape}"
         )
 
-    aligned = _procrustes_align_2d_batched(
+    aligned = procrustes_align_2d_batched(
         arr, model.anchor_indices_dlib68, model.reference_dlib_anchors,
     )
     # Axis-major flat input: [x_0..x_67 | y_0..y_67]

--- a/feat/tests/test_landmarks68_to_mesh478.py
+++ b/feat/tests/test_landmarks68_to_mesh478.py
@@ -16,7 +16,6 @@ matplotlib.use("Agg")  # headless
 from feat import plotting as plt_mod
 from feat.plotting import (
     PCALandmarks68ToMeshModel,
-    _procrustes_align_2d_batched,
     load_landmarks68_to_mesh478_model,
     plot_face_mesh,
     predict_mesh_from_dlib68,
@@ -63,63 +62,6 @@ def stub_bridge_model(monkeypatch):
     )
     monkeypatch.setattr(plt_mod, "_LM68_TO_MESH478_MODEL", model)
     return model
-
-
-# ---------------------------------------------------------------------
-# _procrustes_align_2d_batched
-# ---------------------------------------------------------------------
-
-class TestProcrustes2D:
-    def test_identity_when_anchors_already_match(self, stub_bridge_model):
-        """If a face's anchors already equal the reference, alignment is a no-op."""
-        landmarks = stub_bridge_model.mean_aligned_dlib_landmarks.copy()
-        # Place the reference anchors at the canonical positions
-        landmarks[stub_bridge_model.anchor_indices_dlib68] = (
-            stub_bridge_model.reference_dlib_anchors
-        )
-        aligned = _procrustes_align_2d_batched(
-            landmarks[None],
-            stub_bridge_model.anchor_indices_dlib68,
-            stub_bridge_model.reference_dlib_anchors,
-        )
-        np.testing.assert_allclose(
-            aligned[0, stub_bridge_model.anchor_indices_dlib68],
-            stub_bridge_model.reference_dlib_anchors,
-            atol=1e-3,
-        )
-
-    def test_recovers_reference_after_rotation_scale(self, stub_bridge_model):
-        """Apply a rotation + scale + translation to a face that already
-        matches the reference; alignment should invert it."""
-        landmarks = np.zeros((68, 2), dtype=np.float32)
-        landmarks[stub_bridge_model.anchor_indices_dlib68] = (
-            stub_bridge_model.reference_dlib_anchors
-        )
-        # Apply a known similarity: rotate by 30°, scale 1.5x, translate by (50, -20)
-        theta = np.deg2rad(30.0)
-        R = np.array([[np.cos(theta), -np.sin(theta)],
-                      [np.sin(theta),  np.cos(theta)]], dtype=np.float32)
-        s = 1.5
-        t = np.array([50.0, -20.0], dtype=np.float32)
-        transformed = (s * landmarks @ R.T + t).astype(np.float32)
-        aligned = _procrustes_align_2d_batched(
-            transformed[None],
-            stub_bridge_model.anchor_indices_dlib68,
-            stub_bridge_model.reference_dlib_anchors,
-        )
-        np.testing.assert_allclose(
-            aligned[0, stub_bridge_model.anchor_indices_dlib68],
-            stub_bridge_model.reference_dlib_anchors,
-            atol=1e-2,
-        )
-
-    def test_rejects_wrong_shape(self, stub_bridge_model):
-        with pytest.raises(ValueError, match=r"\(n, 68, 2\)"):
-            _procrustes_align_2d_batched(
-                np.zeros((10, 2), dtype=np.float32),
-                stub_bridge_model.anchor_indices_dlib68,
-                stub_bridge_model.reference_dlib_anchors,
-            )
 
 
 # ---------------------------------------------------------------------

--- a/feat/tests/test_procrustes_align_2d.py
+++ b/feat/tests/test_procrustes_align_2d.py
@@ -1,0 +1,147 @@
+"""Tests for ``feat.utils.image_operations.procrustes_align_2d_batched``.
+
+The 2D Umeyama similarity helper is consumed by the dlib-68 → MP-478 bridge
+in ``feat.plotting`` (PR #305) and may be reused by other landmark-frame
+canonicalization paths. These tests pin its algebraic contract independent
+of any model.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from feat.utils.image_operations import procrustes_align_2d_batched
+
+
+# A small reference anchor configuration that's not pathological — the
+# 8 stable upper-face dlib points used by the v2 bridge.
+DLIB_ANCHOR_INDICES = np.array(
+    [27, 28, 29, 30, 36, 39, 42, 45], dtype=np.int64,
+)
+REF_ANCHORS = np.array([
+    [320.0, 250.0],
+    [322.0, 266.0],
+    [323.0, 281.0],
+    [324.0, 295.0],
+    [270.0, 260.0],
+    [299.0, 258.0],
+    [343.0, 254.0],
+    [372.0, 250.0],
+], dtype=np.float32)
+
+
+def _seed_landmarks_with_anchors_at_ref(K=68):
+    """Build a (K, 2) landmark set where the anchor subset equals REF_ANCHORS.
+    Other landmarks fill in zeros — irrelevant for alignment, which depends
+    only on the anchor subset."""
+    landmarks = np.zeros((K, 2), dtype=np.float32)
+    landmarks[DLIB_ANCHOR_INDICES] = REF_ANCHORS
+    return landmarks
+
+
+# ---------------------------------------------------------------------
+# Algebraic correctness
+# ---------------------------------------------------------------------
+
+class TestAlgebra:
+    def test_identity_when_anchors_already_match(self):
+        """If anchors == reference, alignment is a no-op (transform ≈ identity)."""
+        lm = _seed_landmarks_with_anchors_at_ref()
+        aligned = procrustes_align_2d_batched(
+            lm[None], DLIB_ANCHOR_INDICES, REF_ANCHORS,
+        )
+        np.testing.assert_allclose(
+            aligned[0, DLIB_ANCHOR_INDICES], REF_ANCHORS, atol=1e-3,
+        )
+
+    def test_recovers_reference_after_known_similarity(self):
+        """Apply a known rotate+scale+translate, then align — anchors should
+        come back within numerical tolerance of REF_ANCHORS."""
+        lm = _seed_landmarks_with_anchors_at_ref()
+        theta = np.deg2rad(30.0)
+        R = np.array([[np.cos(theta), -np.sin(theta)],
+                      [np.sin(theta),  np.cos(theta)]], dtype=np.float32)
+        s = 1.5
+        t = np.array([50.0, -20.0], dtype=np.float32)
+        transformed = (s * lm @ R.T + t).astype(np.float32)
+        aligned = procrustes_align_2d_batched(
+            transformed[None], DLIB_ANCHOR_INDICES, REF_ANCHORS,
+        )
+        np.testing.assert_allclose(
+            aligned[0, DLIB_ANCHOR_INDICES], REF_ANCHORS, atol=1e-2,
+        )
+
+    def test_batched_per_face_independence(self):
+        """Two faces in a batch must align independently — different
+        per-face transforms must not cross-contaminate."""
+        lm0 = _seed_landmarks_with_anchors_at_ref()
+        # Face 1: rotated 45° + translated
+        theta = np.deg2rad(45.0)
+        R = np.array([[np.cos(theta), -np.sin(theta)],
+                      [np.sin(theta),  np.cos(theta)]], dtype=np.float32)
+        lm1 = (lm0 @ R.T + np.array([10.0, -5.0], dtype=np.float32)).astype(np.float32)
+        batch = np.stack([lm0, lm1])
+        aligned = procrustes_align_2d_batched(
+            batch, DLIB_ANCHOR_INDICES, REF_ANCHORS,
+        )
+        # Both faces should land their anchors on REF_ANCHORS independently.
+        np.testing.assert_allclose(
+            aligned[0, DLIB_ANCHOR_INDICES], REF_ANCHORS, atol=1e-2,
+        )
+        np.testing.assert_allclose(
+            aligned[1, DLIB_ANCHOR_INDICES], REF_ANCHORS, atol=1e-2,
+        )
+
+    def test_works_with_arbitrary_K(self):
+        """The function isn't 68-specific — should accept any K >= len(anchors)."""
+        # K=200 (e.g., a future denser face model)
+        K = 200
+        lm = np.zeros((K, 2), dtype=np.float32)
+        # Place the anchors at indices 0..7 for variety
+        anchor_idx = np.arange(8, dtype=np.int64)
+        lm[anchor_idx] = REF_ANCHORS
+        aligned = procrustes_align_2d_batched(lm[None], anchor_idx, REF_ANCHORS)
+        assert aligned.shape == (1, K, 2)
+        np.testing.assert_allclose(
+            aligned[0, anchor_idx], REF_ANCHORS, atol=1e-3,
+        )
+
+
+# ---------------------------------------------------------------------
+# Edge cases / errors
+# ---------------------------------------------------------------------
+
+class TestErrorPaths:
+    def test_rejects_2d_input(self):
+        """Caller must pass a leading batch dim; (K, 2) alone must fail."""
+        with pytest.raises(ValueError, match=r"\(n, K, 2\)"):
+            procrustes_align_2d_batched(
+                np.zeros((68, 2), dtype=np.float32),
+                DLIB_ANCHOR_INDICES, REF_ANCHORS,
+            )
+
+    def test_rejects_wrong_last_dim(self):
+        """3-D shape (n, K, 3) — last dim must be 2."""
+        with pytest.raises(ValueError, match=r"\(n, K, 2\)"):
+            procrustes_align_2d_batched(
+                np.zeros((1, 68, 3), dtype=np.float32),
+                DLIB_ANCHOR_INDICES, REF_ANCHORS,
+            )
+
+    def test_rejects_anchor_ref_length_mismatch(self):
+        """anchor_idx and ref_anchors must have matching lengths."""
+        with pytest.raises(ValueError, match=r"ref_anchors shape"):
+            procrustes_align_2d_batched(
+                np.zeros((1, 68, 2), dtype=np.float32),
+                DLIB_ANCHOR_INDICES,           # length 8
+                REF_ANCHORS[:5],               # length 5 — mismatch
+            )
+
+    def test_empty_batch(self):
+        """Zero-row batch should pass through cleanly (parity for the
+        no-faces-detected upstream case)."""
+        out = procrustes_align_2d_batched(
+            np.zeros((0, 68, 2), dtype=np.float32),
+            DLIB_ANCHOR_INDICES, REF_ANCHORS,
+        )
+        assert out.shape == (0, 68, 2)

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -1258,6 +1258,78 @@ def inverse_transform_landmarks_torch(landmarks, boxes):
     return transformed_landmarks.reshape(N, N_landmarks)
 
 
+def procrustes_align_2d_batched(coords, anchor_idx, ref_anchors):
+    """Batched 2D Umeyama similarity alignment to a fixed reference frame.
+
+    For each face, finds the rigid + isotropic-scale transform that best maps
+    its anchor subset to ``ref_anchors`` (least-squares), then applies that
+    transform to all of the face's landmarks. Mirrors the helper used at
+    py-feat training time so inference and training canonicalize landmarks
+    in the same frame.
+
+    Used by the dlib-68 → MP-478 bridge in ``feat.plotting`` and any other
+    consumer that needs to align landmarks to a saved reference (e.g.,
+    cross-detector landmark normalization). Numpy / float64 internally for
+    SVD stability; output cast to float32.
+
+    Args:
+        coords: ``(n, K, 2)`` raw 2-D landmarks per face. ``K`` is whatever
+            number of points the caller carries (e.g., 68 for dlib).
+        anchor_idx: ``(k,)`` int indices selecting stable anchor points
+            from each face's K landmarks.
+        ref_anchors: ``(k, 2)`` reference anchor positions in the target
+            frame (e.g., a population-mean canonical pose).
+
+    Returns:
+        ``(n, K, 2)`` aligned landmarks in the reference frame. Same dtype
+        as the input (after promotion to float32).
+
+    Raises:
+        ValueError: if ``coords`` is not 3-D with last-dim 2, or if
+            ``anchor_idx`` does not match ``ref_anchors`` length.
+    """
+    coords = np.asarray(coords, dtype=np.float32)
+    if coords.ndim != 3 or coords.shape[-1] != 2:
+        raise ValueError(
+            f"coords must have shape (n, K, 2); got {coords.shape}"
+        )
+    anchor_idx = np.asarray(anchor_idx, dtype=np.int64)
+    ref_anchors = np.asarray(ref_anchors, dtype=np.float32)
+    if ref_anchors.shape != (anchor_idx.shape[0], 2):
+        raise ValueError(
+            f"ref_anchors shape {ref_anchors.shape} must be "
+            f"({anchor_idx.shape[0]}, 2) to match anchor_idx length."
+        )
+    N = coords.shape[0]
+    P = coords[:, anchor_idx]  # (N, k, 2)
+    P_mean = P.mean(axis=1, keepdims=True)
+    Q_mean = ref_anchors.mean(axis=0)
+    P_c = P - P_mean
+    Q_c = ref_anchors - Q_mean
+    # SVD in float64 for numerical stability; small (2x2) so cheap regardless.
+    H = np.einsum("ki,nkj->nij", Q_c.astype(np.float64), P_c.astype(np.float64))
+    U, S, Vt = np.linalg.svd(H)
+    UVt = U @ Vt
+    det = np.linalg.det(UVt)
+    d = np.where(det < 0, -1.0, 1.0)
+    D = np.zeros((N, 2, 2), dtype=np.float64)
+    D[:, 0, 0] = 1.0
+    D[:, 1, 1] = d
+    R = U @ D @ Vt
+    var_P = (P_c.astype(np.float64) ** 2).sum(axis=(1, 2))
+    s_num = (S * np.stack([np.ones(N), d], axis=1)).sum(axis=1)
+    s = s_num / np.maximum(var_P, 1e-12)
+    P_mean_sq = P_mean.squeeze(1).astype(np.float64)
+    Rp = np.einsum("nij,nj->ni", R, P_mean_sq)
+    t = Q_mean.astype(np.float64)[None] - s[:, None] * Rp
+    coords_64 = coords.astype(np.float64)
+    aligned = (
+        s[:, None, None] * np.einsum("nvi,nji->nvj", coords_64, R)
+        + t[:, None, :]
+    )
+    return aligned.astype(np.float32)
+
+
 def extract_hog_features(extracted_faces, landmarks, hog_layer=None):
     """Extract HOG features for AU classification using torch-native HOGLayer.
 


### PR DESCRIPTION
## Summary

- Promotes the private ``_procrustes_align_2d_batched`` helper added in PR #305 to a public utility ``procrustes_align_2d_batched`` in ``feat.utils.image_operations``
- Generalizes input contract from ``(n, 68, 2)`` to ``(n, K, 2)`` so the helper is reusable beyond the dlib-68 bridge
- Adds anchor / ref-anchors length-match validation
- No behavior change in the bridge itself

## Why

PR #305 review noted the helper duplicates the training-script's similarity-alignment math and could become the canonical implementation. ``image_operations.py`` already houses 2D landmark transforms (e.g. ``inverse_transform_landmarks_torch``) — natural home. ``face_pose.py`` was considered but it's a pure-PyTorch 3D head-pose module with different intent.

## Implementation

| Change | Where |
|---|---|
| New public ``procrustes_align_2d_batched(coords, anchor_idx, ref_anchors)`` | ``feat/utils/image_operations.py`` (~70 LoC) |
| Drop private duplicate | ``feat/plotting.py`` |
| Import + use the shared helper in ``predict_mesh_from_dlib68`` | ``feat/plotting.py`` |
| Generalize ``(n, 68, 2)`` validation to ``(n, K, 2)`` | the new public helper |
| Add anchor / ref length-match validation | the new public helper |

## Test plan

- [x] New ``test_procrustes_align_2d.py`` (8 dedicated algebraic + error-path tests):
  identity, known-similarity recovery, batched per-face independence, arbitrary K, empty batch, wrong-shape rejection, anchor-length-mismatch rejection
- [x] ``test_landmarks68_to_mesh478.py``: ``TestProcrustes2D`` class removed (tests moved to the dedicated file); bridge tests still pass
- [x] All 44 affected tests pass

## Related work

Follow-up cleanup from PR #305 review (merged today). The original PR sequence (PR7 = plotting + Plotly) resumes after this lands.