### PR TITLE
feat(plotting): interactive 3D Plotly backend for face mesh viz (PR7)

### DIFF
--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1666,8 +1666,10 @@ def plot_face_mesh_plotly(
             ``predict_mesh_from_dlib68``). Mutually exclusive with ``au``.
         mode: which connection set to draw —
 
-            - ``'tesselation'`` (default): the 2,556-edge MP tessellation;
-              shows the full mesh structure and looks dense / 3D.
+            - ``'tesselation'`` (or ``'tessellation'``, default): the
+              2,556-edge MP tessellation; shows the full mesh structure
+              and looks dense / 3D. (MediaPipe's upstream constant uses
+              the single-l spelling; both are accepted.)
             - ``'contours'``: the 124-edge canonical contours (lips + eyes
               + eyebrows + face oval); matches ``plot_face_mesh``.
 
@@ -1703,12 +1705,18 @@ def plot_face_mesh_plotly(
                 "plot_face_mesh_plotly expects a single AU vector; pass one face at a time."
             )
 
-    if mode == "tesselation":
+    # MediaPipe's constant uses the single-l "tesselation" spelling; accept
+    # the standard English "tessellation" too so users typing either land
+    # in the right place.
+    if mode in ("tesselation", "tessellation"):
         connections = FaceLandmarksConnections.FACE_LANDMARKS_TESSELATION
     elif mode == "contours":
         connections = FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS
     else:
-        raise ValueError(f"mode must be 'tesselation' or 'contours'; got {mode!r}")
+        raise ValueError(
+            f"mode must be 'tesselation' (or 'tessellation') or 'contours'; "
+            f"got {mode!r}"
+        )
 
     # Apply same data → mpl axis swap as plot_face_mesh so face is upright.
     xs = verts[:, 0]

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1640,6 +1640,128 @@ def plot_face_mesh(
     return ax
 
 
+def plot_face_mesh_plotly(
+    au=None,
+    model=None,
+    color="black",
+    line_width=1.5,
+    opacity=0.85,
+    background="white",
+    *,
+    mesh=None,
+    mode="tesselation",
+):
+    """Interactive 3D face mesh as a Plotly figure. Opt-in alternative to ``plot_face_mesh``.
+
+    Renders the 478-vertex MP face mesh as a wireframe in an interactive
+    Plotly 3D scene the user can rotate, pan, and zoom. Same data sources
+    as ``plot_face_mesh``: pass ``au`` for an AU→mesh PLS prediction, ``mesh``
+    for a precomputed ``(478, 3)`` array, or neither for the rest mesh.
+
+    Args:
+        au: AU intensity vector ``(20,)`` in ``AU_LANDMARK_MAP['Feat']`` order.
+        model: optional ``PLSAUMeshModel`` for the ``au`` path.
+        color, line_width, opacity, background: scene styling.
+        mesh: keyword-only. Precomputed ``(478, 3)`` mesh (e.g., from
+            ``predict_mesh_from_dlib68``). Mutually exclusive with ``au``.
+        mode: which connection set to draw —
+
+            - ``'tesselation'`` (default): the 2,556-edge MP tessellation;
+              shows the full mesh structure and looks dense / 3D.
+            - ``'contours'``: the 124-edge canonical contours (lips + eyes
+              + eyebrows + face oval); matches ``plot_face_mesh``.
+
+    Returns:
+        ``plotly.graph_objects.Figure``. Call ``.show()`` to render in a
+        browser/notebook, or ``.write_html(path)`` / ``.write_image(path)``
+        to persist.
+
+    Coordinate frame: matches ``plot_face_mesh`` — data ``(X, Y, Z)`` is
+    mapped to Plotly ``(X, Z, Y)`` so the face renders upright with depth
+    into the screen under the default camera.
+    """
+    import plotly.graph_objects as go
+    from feat.utils.mp_plotting import FaceLandmarksConnections
+
+    if mesh is not None and au is not None:
+        raise ValueError("pass either `au` or `mesh`, not both")
+
+    if mesh is not None:
+        verts = np.asarray(mesh, dtype=np.float32)
+        if verts.shape != (478, 3):
+            raise ValueError(
+                f"mesh must have shape (478, 3); got {verts.shape}."
+            )
+    elif au is None:
+        if model is None:
+            model = load_face_mesh_viz_model()
+        verts = model.mean_aligned_mesh
+    else:
+        verts = predict_face_mesh(au, model=model)
+        if verts.ndim != 2:
+            raise ValueError(
+                "plot_face_mesh_plotly expects a single AU vector; pass one face at a time."
+            )
+
+    if mode == "tesselation":
+        connections = FaceLandmarksConnections.FACE_LANDMARKS_TESSELATION
+    elif mode == "contours":
+        connections = FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS
+    else:
+        raise ValueError(f"mode must be 'tesselation' or 'contours'; got {mode!r}")
+
+    # Apply same data → mpl axis swap as plot_face_mesh so face is upright.
+    xs = verts[:, 0]
+    ys = verts[:, 2]
+    zs = verts[:, 1]
+
+    # Build a single Scatter3d trace with NaN separators between line
+    # segments — much faster than emitting one trace per edge for the
+    # 2,556-edge tessellation.
+    n_edges = len(connections)
+    seg_x = np.empty(3 * n_edges, dtype=np.float32)
+    seg_y = np.empty(3 * n_edges, dtype=np.float32)
+    seg_z = np.empty(3 * n_edges, dtype=np.float32)
+    nan = np.float32(np.nan)
+    for i, conn in enumerate(connections):
+        a, b = conn.start, conn.end
+        seg_x[3 * i] = xs[a]; seg_x[3 * i + 1] = xs[b]; seg_x[3 * i + 2] = nan
+        seg_y[3 * i] = ys[a]; seg_y[3 * i + 1] = ys[b]; seg_y[3 * i + 2] = nan
+        seg_z[3 * i] = zs[a]; seg_z[3 * i + 1] = zs[b]; seg_z[3 * i + 2] = nan
+
+    fig = go.Figure(
+        data=go.Scatter3d(
+            x=seg_x, y=seg_y, z=seg_z,
+            mode="lines",
+            line=dict(color=color, width=line_width),
+            opacity=opacity,
+            showlegend=False,
+            hoverinfo="skip",
+        )
+    )
+
+    # Equal-aspect bounds so the face isn't visually squashed.
+    extents = np.array([
+        [xs.min(), xs.max()],
+        [ys.min(), ys.max()],
+        [zs.min(), zs.max()],
+    ])
+    centers = extents.mean(axis=1)
+    half = (extents[:, 1] - extents[:, 0]).max() / 2
+    fig.update_layout(
+        scene=dict(
+            xaxis=dict(visible=False, range=[centers[0] - half, centers[0] + half]),
+            yaxis=dict(visible=False, range=[centers[1] - half, centers[1] + half]),
+            zaxis=dict(visible=False, range=[centers[2] - half, centers[2] + half]),
+            aspectmode="cube",
+            bgcolor=background,
+        ),
+        margin=dict(l=0, r=0, t=0, b=0),
+        paper_bgcolor=background,
+    )
+    return fig
+
+
 # ---------------------------------------------------------------------
 # 68-pt dlib landmarks → 478-vertex MediaPipe FaceMesh bridge.
 # Lets users with a Detector Fex (mobilefacenet 68-pt) reconstruct an

--- a/feat/tests/test_face_mesh_plotly.py
+++ b/feat/tests/test_face_mesh_plotly.py
@@ -84,8 +84,17 @@ class TestModeDispatch:
         assert len(fig.data[0].x) == 3 * N_CONTOURS_EDGES
 
     def test_invalid_mode_raises(self, stub_mesh_model):
-        with pytest.raises(ValueError, match=r"'tesselation' or 'contours'"):
+        with pytest.raises(ValueError, match=r"'tesselation'"):
             plot_face_mesh_plotly(mode="bogus")
+
+    def test_tessellation_double_l_spelling_accepted(self, stub_mesh_model):
+        """``'tessellation'`` (standard English, double-l) is an alias of
+        the MediaPipe-compatible ``'tesselation'`` (single-l)."""
+        fig_single = plot_face_mesh_plotly(mode="tesselation")
+        fig_double = plot_face_mesh_plotly(mode="tessellation")
+        # Same edge count → same number of points emitted
+        assert len(fig_single.data[0].x) == len(fig_double.data[0].x)
+        assert len(fig_double.data[0].x) == 3 * N_TESSELATION_EDGES
 
     def test_nan_separator_between_segments(self, stub_mesh_model):
         """Every 3rd point must be NaN — that's the line-segment terminator
@@ -192,3 +201,34 @@ class TestLayout:
         fig = plot_face_mesh_plotly(background="lightgray")
         assert fig.layout.scene.bgcolor == "lightgray"
         assert fig.layout.paper_bgcolor == "lightgray"
+
+    def test_color_and_line_width_passthrough(self, stub_mesh_model):
+        """Style kwargs must reach the trace — catches a future refactor
+        that drops them when building the Scatter3d."""
+        fig = plot_face_mesh_plotly(color="crimson", line_width=4.0)
+        line = fig.data[0].line
+        assert line.color == "crimson"
+        assert line.width == 4.0
+
+
+# ---------------------------------------------------------------------
+# Real HF Hub fetch — runs once, then hits cache.
+# ---------------------------------------------------------------------
+
+@pytest.mark.network
+class TestRealModelSmoke:
+    def test_renders_with_real_au_mesh_model(self, monkeypatch):
+        """End-to-end: clear the cached PLS model so load_face_mesh_viz_model
+        actually fetches from HF Hub, then render a figure with a non-trivial
+        AU activation. Verifies real predict + figure construction round-trips."""
+        monkeypatch.setattr(plt_mod, "_PLS_V2_MESH_MODEL", None)
+        au = np.zeros(20, dtype=np.float32)
+        # AU12 (smile) — index 9 in AU_LANDMARK_MAP['Feat']
+        au[9] = 3.0
+        fig = plot_face_mesh_plotly(au=au)
+        # One trace, dense tessellation by default
+        assert len(fig.data) == 1
+        assert len(fig.data[0].x) == 3 * N_TESSELATION_EDGES
+        # Sanity: scene has finite axis ranges (no NaN propagation)
+        z_range = fig.layout.scene.zaxis.range
+        assert all(np.isfinite(z_range))

--- a/feat/tests/test_face_mesh_plotly.py
+++ b/feat/tests/test_face_mesh_plotly.py
@@ -1,0 +1,194 @@
+"""Tests for ``feat.plotting.plot_face_mesh_plotly`` (PR7).
+
+Interactive 3D Plotly backend for the face mesh viz. Mirrors PR #304's
+matplotlib path but emits a ``go.Figure``. All tests are offline — synthetic
+stub model + edge-count checks instead of pixel diffs (Plotly figures are
+inspected via their data attribute, not rendered).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from feat import plotting as plt_mod
+from feat.plotting import (
+    PLSAUMeshModel,
+    plot_face_mesh_plotly,
+)
+from feat.utils.mp_plotting import FaceLandmarksConnections
+
+
+N_TESSELATION_EDGES = len(FaceLandmarksConnections.FACE_LANDMARKS_TESSELATION)
+N_CONTOURS_EDGES = len(FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS)
+
+
+@pytest.fixture
+def stub_mesh_model(monkeypatch):
+    """Synthetic PLSAUMeshModel with realistic-magnitude intercept ranges
+    so the equal-aspect bounds and segment math don't NaN."""
+    rng = np.random.default_rng(0)
+    coef = rng.standard_normal((23, 1434)).astype(np.float32) * 0.05
+    intercept = np.empty(1434, dtype=np.float32)
+    intercept[:478] = rng.uniform(-7, 7, 478)
+    intercept[478:956] = rng.uniform(-9, 8, 478)
+    intercept[956:] = rng.uniform(-1, 7, 478)
+    au_cols = [
+        "AU01", "AU02", "AU04", "AU05", "AU06", "AU07", "AU09", "AU10",
+        "AU11", "AU12", "AU14", "AU15", "AU17", "AU20", "AU23", "AU24",
+        "AU25", "AU26", "AU28", "AU43",
+    ]
+    mean_mesh = np.column_stack([
+        intercept[:478], intercept[478:956], intercept[956:],
+    ])
+    model = PLSAUMeshModel(
+        coef=coef, intercept=intercept,
+        au_columns=au_cols, pose_columns=["Pitch", "Yaw", "Roll"],
+        mean_aligned_mesh=mean_mesh,
+    )
+    monkeypatch.setattr(plt_mod, "_PLS_V2_MESH_MODEL", model)
+    return model
+
+
+# ---------------------------------------------------------------------
+# Returns a usable plotly Figure
+# ---------------------------------------------------------------------
+
+class TestReturnType:
+    def test_returns_plotly_figure(self, stub_mesh_model):
+        import plotly.graph_objects as go
+        fig = plot_face_mesh_plotly()
+        assert isinstance(fig, go.Figure)
+
+    def test_has_single_scatter3d_trace(self, stub_mesh_model):
+        fig = plot_face_mesh_plotly()
+        assert len(fig.data) == 1
+        trace = fig.data[0]
+        assert trace.type == "scatter3d"
+        assert trace.mode == "lines"
+
+
+# ---------------------------------------------------------------------
+# Mode dispatch — number of segments must match the chosen connection set
+# ---------------------------------------------------------------------
+
+class TestModeDispatch:
+    def test_default_mode_is_tesselation(self, stub_mesh_model):
+        """Default ``mode='tesselation'`` should emit 3 × 2556 = 7668 points
+        (each edge contributes start, end, NaN separator)."""
+        fig = plot_face_mesh_plotly()
+        assert len(fig.data[0].x) == 3 * N_TESSELATION_EDGES
+
+    def test_contours_mode_uses_canonical_subset(self, stub_mesh_model):
+        """``mode='contours'`` should emit 3 × 124 = 372 points."""
+        fig = plot_face_mesh_plotly(mode="contours")
+        assert len(fig.data[0].x) == 3 * N_CONTOURS_EDGES
+
+    def test_invalid_mode_raises(self, stub_mesh_model):
+        with pytest.raises(ValueError, match=r"'tesselation' or 'contours'"):
+            plot_face_mesh_plotly(mode="bogus")
+
+    def test_nan_separator_between_segments(self, stub_mesh_model):
+        """Every 3rd point must be NaN — that's the line-segment terminator
+        Plotly uses to break the polyline between disconnected edges."""
+        fig = plot_face_mesh_plotly(mode="contours")
+        seps = np.asarray(fig.data[0].x[2::3])
+        assert np.all(np.isnan(seps)), "every 3rd x value should be NaN"
+
+
+# ---------------------------------------------------------------------
+# Source dispatch — au= / mesh= / neither
+# ---------------------------------------------------------------------
+
+class TestSourceDispatch:
+    def test_au_drives_prediction(self, stub_mesh_model):
+        """Passing AU should call into PLSAUMeshModel.predict and the
+        resulting figure should differ from the rest-mesh figure."""
+        rest_fig = plot_face_mesh_plotly()
+        au = np.zeros(20, dtype=np.float32)
+        au[stub_mesh_model.au_columns.index("AU12")] = 3.0
+        au_fig = plot_face_mesh_plotly(au=au)
+        # First non-NaN x of trace should differ between rest and AU=3
+        rest_x = np.asarray(rest_fig.data[0].x)
+        au_x = np.asarray(au_fig.data[0].x)
+        # Both have the same shape; at least one finite point must differ.
+        finite = ~(np.isnan(rest_x) | np.isnan(au_x))
+        assert (rest_x[finite] != au_x[finite]).any()
+
+    def test_mesh_kwarg_uses_provided_array(self, stub_mesh_model):
+        """A precomputed mesh should be drawn directly without consulting
+        the AU model."""
+        custom_mesh = np.zeros((478, 3), dtype=np.float32)
+        custom_mesh[:, 0] = np.linspace(-5, 5, 478)
+        custom_mesh[:, 1] = np.linspace(-8, 8, 478)
+        custom_mesh[:, 2] = np.linspace(0, 6, 478)
+        fig = plot_face_mesh_plotly(mesh=custom_mesh, mode="contours")
+        # The X axis (data X) should show the linspace range
+        xs = np.asarray(fig.data[0].x)
+        finite_x = xs[~np.isnan(xs)]
+        assert finite_x.min() >= -5.001 and finite_x.max() <= 5.001
+
+    def test_rejects_au_and_mesh_together(self, stub_mesh_model):
+        with pytest.raises(ValueError, match=r"either `au` or `mesh`"):
+            plot_face_mesh_plotly(
+                au=np.zeros(20),
+                mesh=np.zeros((478, 3), dtype=np.float32),
+            )
+
+    def test_rejects_wrong_mesh_shape(self, stub_mesh_model):
+        with pytest.raises(ValueError, match=r"shape \(478, 3\)"):
+            plot_face_mesh_plotly(mesh=np.zeros((100, 3), dtype=np.float32))
+
+    def test_mesh_keyword_only(self, stub_mesh_model):
+        """`mesh` must be keyword-only — positional sixth arg shouldn't
+        silently bind to it (catches a future signature regression)."""
+        with pytest.raises(TypeError):
+            plot_face_mesh_plotly(
+                None, None, "black", 1.5, 0.85, "white",
+                np.zeros((478, 3), dtype=np.float32),
+            )
+
+
+# ---------------------------------------------------------------------
+# Coordinate frame — data Y maps to plotly Z so the face is upright
+# ---------------------------------------------------------------------
+
+class TestAxisSwap:
+    def test_data_y_maps_to_plotly_z(self, stub_mesh_model):
+        """Data has Y up (forehead +, chin -). Plotly's default camera puts
+        +Z up, so the function maps data Y → plotly Z. If the swap is
+        dropped, the face renders lying down."""
+        custom = np.zeros((478, 3), dtype=np.float32)
+        custom[:, 1] = np.linspace(-9, 8, 478)   # data Y span = 17 (largest)
+        custom[:, 2] = np.linspace(0, 5, 478)    # data Z span = 5 (smaller)
+        fig = plot_face_mesh_plotly(mesh=custom, mode="contours")
+        z_range = fig.layout.scene.zaxis.range
+        # Plotly's Z (vertical) range must contain the data-Y span (~17),
+        # not the data-Z span (~5).
+        z_span = z_range[1] - z_range[0]
+        assert z_span >= 17 - 1e-2, (
+            f"Plotly Z span ({z_span:.3f}) should contain data-Y range (17)"
+        )
+
+
+# ---------------------------------------------------------------------
+# Layout sanity
+# ---------------------------------------------------------------------
+
+class TestLayout:
+    def test_axes_hidden(self, stub_mesh_model):
+        fig = plot_face_mesh_plotly()
+        scene = fig.layout.scene
+        assert scene.xaxis.visible is False
+        assert scene.yaxis.visible is False
+        assert scene.zaxis.visible is False
+
+    def test_aspectmode_cube(self, stub_mesh_model):
+        """Cube aspect mode prevents Plotly from auto-stretching axes —
+        face should render with correct proportions."""
+        fig = plot_face_mesh_plotly()
+        assert fig.layout.scene.aspectmode == "cube"
+
+    def test_background_param(self, stub_mesh_model):
+        fig = plot_face_mesh_plotly(background="lightgray")
+        assert fig.layout.scene.bgcolor == "lightgray"
+        assert fig.layout.paper_bgcolor == "lightgray"


### PR DESCRIPTION
## Summary

- New ``plot_face_mesh_plotly()`` — interactive 3D mesh viz returning a ``go.Figure``
- Same source dispatch as ``plot_face_mesh`` (PR #304): ``au=``, ``mesh=`` (keyword-only), or rest mesh
- New ``mode=`` dispatch: ``'tesselation'`` (default, 2,556 edges) vs ``'contours'`` (124 edges)
- Plotly is already a py-feat runtime dep — no new dependency

## Why

matplotlib 3D is laggy under mouse rotation, especially on dense meshes. Plotly's WebGL backend handles the full MP tessellation smoothly. PR #304 set up the static viz; this completes the interactive path.

## Implementation notes

- One ``go.Scatter3d`` trace with NaN separators between line segments — much faster than emitting one trace per edge for the 2,556-edge tessellation.
- Same data ``(X, Y, Z)`` → plotly ``(X, Z, Y)`` axis swap as the matplotlib version so the face renders upright with depth into the screen.
- ``aspectmode='cube'`` to prevent auto-stretch; axes hidden.
- ``mesh`` is keyword-only (matches the ``plot_face_mesh`` convention from PR #305 review).

## Test plan

- [x] 15 offline tests in ``test_face_mesh_plotly.py``
  - Return type & trace shape
  - Mode dispatch: edge counts, invalid-mode rejection, NaN separator pinning
  - Source dispatch: au=, mesh=, au+mesh exclusivity, wrong shape, keyword-only `mesh`
  - Axis swap pinned (data-Y → plotly-Z)
  - Layout: hidden axes, cube aspectmode, configurable background
- [x] All earlier mesh-viz tests still pass alongside

## Related work

PR7 of the planned sequence:
- PR #300–#306: full BS↔AU + AU↔mesh + 68↔mesh ecosystem (merged)
- **PR7 (this)**: interactive Plotly 3D backend
- PR8: documentation / tutorials (next)