### PR TITLE
Detectorv2: RetinaFace + v2.3 multitask model + ArcFace identity

### DIFF
--- a/docs/benchmarks/blackwell-allconfigs-speed.md
+++ b/docs/benchmarks/blackwell-allconfigs-speed.md
@@ -1,0 +1,131 @@
+# py-feat detector benchmark — 2026-05-31 07:21:14
+
+## Run metadata
+
+- **Date:** 2026-05-31 07:21:14
+- **py-feat version:** 0.7.0
+- **Git commit:** 29a11e1
+- **Host:** liquidswords2 (x86_64, 128 CPUs)
+- **Python:** 3.12.13
+- **PyTorch:** 2.11.0+cu128
+- **GPU:** CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition
+- **OMP_NUM_THREADS:** `1`
+- **Devices swept:** ['cuda']
+- **Batch sizes:** [1, 4, 16]
+- **DataLoader workers:** [0]
+
+Each timed call is preceded by one untimed warmup; the timed-call wall time is reported.
+
+## Video: short (72 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 5.25 | 72.9 | 13.7 |
+| cuda | 4 | 2.58 | 35.9 | 27.9 |
+| cuda | 16 | 1.74 | 24.1 | 41.4 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 3.66 | 50.8 | 19.7 |
+| cuda | 4 | 1.05 | 14.6 | 68.4 |
+| cuda | 16 | 0.54 | 7.6 | 132.1 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 3.05 | 42.3 | 23.6 |
+| cuda | 4 | 0.85 | 11.8 | 85.0 |
+| cuda | 16 | 0.71 | 9.9 | 101.5 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 2.34 | 32.5 | 30.8 |
+| cuda | 4 | 0.68 | 9.5 | 105.7 |
+| cuda | 16 | 0.32 | 4.5 | 223.1 |
+
+
+## Video: long (472 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 35.60 | 75.4 | 13.3 |
+| cuda | 4 | 18.76 | 39.7 | 25.2 |
+| cuda | 16 | 15.34 | 32.5 | 30.8 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 23.10 | 48.9 | 20.4 |
+| cuda | 4 | 7.34 | 15.5 | 64.3 |
+| cuda | 16 | 2.92 | 6.2 | 161.5 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 20.30 | 43.0 | 23.3 |
+| cuda | 4 | 5.85 | 12.4 | 80.7 |
+| cuda | 16 | 2.43 | 5.2 | 194.0 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 15.86 | 33.6 | 29.8 |
+| cuda | 4 | 4.70 | 10.0 | 100.3 |
+| cuda | 16 | 2.19 | 4.6 | 215.5 |
+
+
+## Images: 16 x multi_face.jpg = 80 faces
+
+### img2pose
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 1 | 2.39 | 149.3 | 80 |
+| cuda | 4 | 1.18 | 73.8 | 80 |
+| cuda | 16 | 1.10 | 69.0 | 80 |
+
+
+### retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 1 | 1.76 | 109.7 | 80 |
+| cuda | 4 | 0.65 | 40.8 | 80 |
+| cuda | 16 | 0.52 | 32.7 | 80 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 1 | 0.80 | 50.0 | 80 |
+| cuda | 4 | 0.32 | 20.1 | 80 |
+| cuda | 16 | 1.52 | 94.8 | 80 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 1 | 0.65 | 40.7 | 80 |
+| cuda | 4 | 0.32 | 19.9 | 80 |
+| cuda | 16 | 0.37 | 23.4 | 80 |
+

--- a/docs/benchmarks/blackwell-detectorv2-bf16.md
+++ b/docs/benchmarks/blackwell-detectorv2-bf16.md
@@ -1,0 +1,86 @@
+# py-feat detector benchmark — 2026-05-31 07:26:28
+
+## Run metadata
+
+- **Date:** 2026-05-31 07:26:28
+- **py-feat version:** 0.7.0
+- **Git commit:** dcd035c
+- **Host:** liquidswords2 (x86_64, 128 CPUs)
+- **Python:** 3.12.13
+- **PyTorch:** 2.11.0+cu128
+- **GPU:** CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition
+- **OMP_NUM_THREADS:** `1`
+- **Devices swept:** ['cuda']
+- **Batch sizes:** [16]
+- **DataLoader workers:** [0]
+
+Each timed call is preceded by one untimed warmup; the timed-call wall time is reported.
+
+## Video: short (72 frames)
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 0.97 | 13.5 | 74.3 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 1.43 | 19.9 | 50.2 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 0.33 | 4.6 | 216.7 |
+
+
+## Video: long (472 frames)
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 4.11 | 8.7 | 115.0 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 3.13 | 6.6 | 150.6 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 16 | 1.98 | 4.2 | 239.0 |
+
+
+## Images: 16 x multi_face.jpg = 80 faces
+
+### retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 16 | 0.58 | 36.0 | 80 |
+
+
+### MPDetector retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 16 | 1.40 | 87.7 | 80 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 16 | 0.32 | 20.1 | 80 |
+

--- a/docs/benchmarks/detectorv2-speed.md
+++ b/docs/benchmarks/detectorv2-speed.md
@@ -1,0 +1,39 @@
+# py-feat detector benchmark — 2026-05-31 07:13:22
+
+## Run metadata
+
+- **Date:** 2026-05-31 07:13:22
+- **py-feat version:** 0.7.0
+- **Git commit:** fcabbf0
+- **Host:** liquidswords2 (x86_64, 128 CPUs)
+- **Python:** 3.12.13
+- **PyTorch:** 2.11.0+cu128
+- **GPU:** CUDA 12.8, NVIDIA GeForce RTX 3090
+- **OMP_NUM_THREADS:** `1`
+- **Devices swept:** ['cuda']
+- **Batch sizes:** [1, 4, 16]
+- **DataLoader workers:** [0]
+
+Each timed call is preceded by one untimed warmup; the timed-call wall time is reported.
+
+## Video: short (72 frames)
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cuda | 1 | 2.43 | 33.8 | 29.6 |
+| cuda | 4 | 1.06 | 14.8 | 67.8 |
+| cuda | 16 | 0.83 | 11.5 | 86.8 |
+
+
+## Images: 16 x multi_face.jpg = 80 faces
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cuda | 1 | 0.99 | 62.0 | 80 |
+| cuda | 4 | 0.77 | 48.1 | 80 |
+| cuda | 16 | 0.71 | 44.2 | 80 |
+

--- a/feat/__init__.py
+++ b/feat/__init__.py
@@ -48,4 +48,10 @@ __all__ = ["detector", "data", "utils", "plotting", "transforms", "__version__"]
 
 from .data import Fex  # noqa: F401, E402
 from .detector import Detector  # noqa: F401, E402
+from .detector_v2 import Detectorv2  # noqa: F401, E402
+
+# Explicit version alias: Detectorv1 == the original Detector (XGB/SVM AU +
+# ResMaskNet emotion + L2CS gaze). Detector is kept for backward compat.
+Detectorv1 = Detector
+
 from .version import __version__  # noqa: E402

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -104,8 +104,13 @@ class Detectorv2(nn.Module):
         call across all faces in the batch, with no-detection frames carrying a
         single NaN-bbox placeholder so forward() sees >= 1 row per frame.
         """
-        # Convert once on device. RetinaFace wants [0,255]; crops want [0,1].
-        frames_px = convert_image_to_tensor(images, img_type="float32").to(self.device)
+        # The DataLoader hands us a uint8 [B,3,H,W] tensor. Cast to float on the
+        # GPU, not the CPU: transferring uint8 moves 1/4 the bytes and the float
+        # cast is ~free on-device. (convert_image_to_tensor with img_type set
+        # casts to float32 on CPU first — ~19ms + a 4x-larger H2D copy on the
+        # multi-face bench.) Keep the helper only for the dim/format handling.
+        frames = convert_image_to_tensor(images)              # uint8, no cast
+        frames_px = frames.to(self.device, non_blocking=True).float()
         frames_unit = frames_px / 255.0
 
         rf_outputs = self.face_detector(frames_px)

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -67,7 +67,7 @@ class Detectorv2(nn.Module):
     """
 
     def __init__(self, device="cpu", face_detection_threshold=0.5,
-                 identity_model="arcface", multitask_weights=None):
+                 identity_model="arcface", multitask_weights=None, amp=None):
         super().__init__()
         self.device = set_torch_device(device)
         self.face_size = CHIP_SIZE
@@ -75,7 +75,7 @@ class Detectorv2(nn.Module):
 
         self.face_detector = Retinaface(device=self.device)
         self.multitask = MultitaskModel(device=self.device,
-                                        weights_path=multitask_weights)
+                                        weights_path=multitask_weights, amp=amp)
         self.identity_detector = (
             ArcFace(backbone="r50") if identity_model == "arcface" else None
         )

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -260,6 +260,16 @@ class Detectorv2(nn.Module):
             "FrameWidth": frame_w.cpu().detach().numpy().astype(np.float64),
         })
 
+        # No-detection rows carry a NaN placeholder bbox (see detect_faces).
+        # The model + ArcFace still ran on a zeroed crop, so blank out every
+        # prediction for those rows — only the (already-NaN) facebox and the
+        # frame metadata stay meaningful, matching Detectorv1's behavior.
+        no_det = np.isnan(new_bboxes.cpu().numpy()).any(axis=1)
+        if no_det.any():
+            for df in (feat_landmarks, feat_poses, feat_aus, feat_emotions,
+                       feat_va, feat_gaze, feat_identities, feat_mesh):
+                df.loc[no_det, :] = np.nan
+
         return pd.concat(
             [feat_faceboxes, feat_landmarks, feat_poses, feat_aus, feat_emotions,
              feat_va, feat_gaze, feat_identities, feat_mesh, feat_frame_meta],
@@ -269,17 +279,24 @@ class Detectorv2(nn.Module):
     def _mesh_to_original_frame(self, mesh, new_bboxes, pad_left, pad_top, scale):
         """[N,478,3] mesh in 224-chip coords -> original-frame coords.
 
-        x,y go chip(224) -> +offset -> normalize by 256 -> inverse_transform via
-        new_bboxes (padded frame) -> invert DataLoader Rescale. z (relative
-        depth) is passed through unchanged.
+        Per-vertex affine: chip(224) px -> +center-crop offset -> normalize by the
+        256 chip size -> map into the padded-frame crop box (new_bboxes) ->
+        invert the DataLoader Rescale (pad + scale). z (relative depth) passes
+        through unchanged.
+
+        NB: do the affine directly rather than via
+        ``inverse_transform_landmarks_torch`` — that helper reshapes its input as
+        interleaved (x0,y0,x1,y1,...) pairs, but our coords are axis-major, so
+        feeding it here would scramble x/y scaling on non-square boxes.
         """
-        N = mesh.shape[0]
         xy01 = (mesh[:, :, :2] + _CROP_OFFSET) / float(CHIP_SIZE)   # [N,478,2] in [0,1]
-        flat = torch.cat([xy01[:, :, 0], xy01[:, :, 1]], dim=1)     # [N, 2*478] axis-major
-        padded = inverse_transform_landmarks_torch(flat, new_bboxes)  # padded frame
-        padded = padded.reshape(N, 2, N_MESH).permute(0, 2, 1)     # [N,478,2] (x,y)
-        x = (padded[:, :, 0] - pad_left[:, None]) / scale[:, None]
-        y = (padded[:, :, 1] - pad_top[:, None]) / scale[:, None]
+        left = new_bboxes[:, 0]                                     # [N]
+        top = new_bboxes[:, 1]
+        w = new_bboxes[:, 2] - left
+        h = new_bboxes[:, 3] - top
+        # padded-frame coords, then invert Rescale to original frame.
+        x = (xy01[:, :, 0] * w[:, None] + left[:, None] - pad_left[:, None]) / scale[:, None]
+        y = (xy01[:, :, 1] * h[:, None] + top[:, None] - pad_top[:, None]) / scale[:, None]
         return torch.stack([x, y, mesh[:, :, 2]], dim=-1)          # [N,478,3]
 
     # ------------------------------------------------------------------ #

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -1,0 +1,352 @@
+"""Detectorv2 — RetinaFace + the v2.3 multitask model + ArcFace identity.
+
+A single forward of the multitask model yields AU (24), emotion (8), valence/
+arousal, gaze, head pose, and a 478-point face mesh; ArcFace adds identity
+embeddings. Outputs a native-v2 :class:`~feat.data.Fex` whose landmark block is
+the dlib-68 subset derived from the 478 mesh (so Fex helpers expecting 68
+points keep working), with the full 478 mesh available in ``mesh_*`` columns.
+
+The model consumes a 256x256 RetinaFace crop (expand_bbox=1.2), exactly as its
+training chips were produced; preprocessing to the 224 model input is handled by
+:class:`~feat.multitask.inference.MultitaskModel`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn
+from tqdm import tqdm
+from torch.utils.data import DataLoader
+
+from feat.data import Fex, ImageDataset, TensorDataset, VideoDataset
+from feat.utils import set_torch_device
+from feat.utils.image_operations import (
+    extract_face_from_bbox_torch,
+    convert_image_to_tensor,
+    convert_bbox_output,
+    inverse_transform_landmarks_torch,
+    per_face_padding_inversion_terms,
+)
+from feat.utils import (
+    openface_2d_landmark_columns,
+    FEAT_FACEBOX_COLUMNS,
+    FEAT_IDENTITY_COLUMNS,
+    FEAT_FACEPOSE_COLUMNS_6D,
+    FEAT_GAZE_COLUMNS,
+    N_OPENFACE_LANDMARKS,
+)
+from feat.face_detectors.Retinaface.Retinaface_test import Retinaface
+from feat.identity_detectors.arcface.arcface_model import ArcFace
+from feat.multitask import (
+    N_MESH,
+    AU_COLUMNS_V2,
+    EMOTION_COLUMNS_V2,
+    VA_COLUMNS_V2,
+    MESH_COLUMNS_V2,
+)
+from feat.multitask.inference import (
+    MultitaskModel,
+    CHIP_SIZE,
+    MODEL_INPUT,
+    EXPAND_BBOX,
+    _DLIB68_IDX,
+)
+
+# Crop offset from the 256 chip to the 224 model input (centre crop).
+_CROP_OFFSET = (CHIP_SIZE - MODEL_INPUT) // 2  # 16
+
+
+class Detectorv2(nn.Module):
+    """Multitask face-behavior detector (v2.3 model).
+
+    Pipeline: RetinaFace -> 256 crop -> multitask model (AU/emotion/V-A/gaze/
+    mesh/pose) + ArcFace identity -> Fex.
+    """
+
+    def __init__(self, device="cpu", face_detection_threshold=0.5,
+                 identity_model="arcface", multitask_weights=None):
+        super().__init__()
+        self.device = set_torch_device(device)
+        self.face_size = CHIP_SIZE
+        self.face_detection_threshold = face_detection_threshold
+
+        self.face_detector = Retinaface(device=self.device)
+        self.multitask = MultitaskModel(device=self.device,
+                                        weights_path=multitask_weights)
+        self.identity_detector = (
+            ArcFace(backbone="r50") if identity_model == "arcface" else None
+        )
+        if self.identity_detector is not None:
+            self.identity_detector.to(self.device)
+            self.identity_detector.eval()
+
+        self._idx68 = _DLIB68_IDX.to(self.device)
+        self.info = dict(
+            face_model="retinaface",
+            multitask_model="face_multitask_v1",
+            identity_model=identity_model,
+            facepose_model="multitask",
+            gaze_model="multitask",
+        )
+
+    def __repr__(self):
+        return (f"Detectorv2(face=retinaface, multitask=face_multitask_v1, "
+                f"identity={self.info['identity_model']}, device={self.device})")
+
+    # ------------------------------------------------------------------ #
+    def detect_faces(self, images, face_detection_threshold=0.5):
+        """RetinaFace detection + 256 crops. Returns per-frame dicts.
+
+        Mirrors Detector.detect_faces' batched-crop strategy: one grid_sample
+        call across all faces in the batch, with no-detection frames carrying a
+        single NaN-bbox placeholder so forward() sees >= 1 row per frame.
+        """
+        frames_unit = convert_image_to_tensor(images, img_type="float32") / 255.0
+        frames_unit = frames_unit.to(self.device)
+        frames_px = convert_image_to_tensor(images, img_type="float32").to(self.device)
+
+        rf_outputs = self.face_detector(frames_px)
+        per_image_dets = []
+        for image_dets in rf_outputs:
+            if image_dets:
+                arr = torch.tensor(image_dets, dtype=torch.float32, device=self.device)
+                keep = arr[:, 4] >= face_detection_threshold
+                per_image_dets.append({"boxes": arr[keep, :4], "scores": arr[keep, 4]})
+            else:
+                per_image_dets.append({
+                    "boxes": torch.empty((0, 4), device=self.device),
+                    "scores": torch.empty((0,), device=self.device),
+                })
+
+        B = len(per_image_dets)
+        bbox_chunks, score_chunks, n_per_frame = [], [], []
+        for det in per_image_dets:
+            if det["boxes"].numel() != 0:
+                bbox_chunks.append(det["boxes"])
+                score_chunks.append(det["scores"])
+                n_per_frame.append(det["boxes"].shape[0])
+            else:
+                bbox_chunks.append(torch.full((1, 4), float("nan"), device=self.device))
+                score_chunks.append(torch.zeros((1,), device=self.device))
+                n_per_frame.append(1)
+
+        all_bboxes = torch.cat(bbox_chunks, dim=0)
+        all_scores = torch.cat(score_chunks, dim=0)
+        n_per_frame_t = torch.tensor(n_per_frame, device=self.device)
+        all_frame_idx = torch.repeat_interleave(
+            torch.arange(B, device=self.device), n_per_frame_t
+        )
+
+        bboxes_for_extract = torch.where(
+            torch.isnan(all_bboxes), torch.zeros_like(all_bboxes), all_bboxes
+        )
+        all_faces, all_new_bboxes = extract_face_from_bbox_torch(
+            frames_unit, bboxes_for_extract,
+            face_size=self.face_size, expand_bbox=EXPAND_BBOX,
+            frame_idx=all_frame_idx,
+        )
+
+        no_det = torch.isnan(all_bboxes).any(dim=1)
+        if no_det.any():
+            all_faces = all_faces.clone()
+            all_faces[no_det] = 0
+            all_new_bboxes = all_new_bboxes.clone().to(torch.float32)
+            all_new_bboxes[no_det] = float("nan")
+
+        image_size = tuple(frames_unit.shape[-2:])
+        results, cursor = [], 0
+        for i in range(B):
+            n = n_per_frame[i]
+            sl = slice(cursor, cursor + n)
+            results.append({
+                "face_id": i,
+                "faces": all_faces[sl],
+                "boxes": all_bboxes[sl],
+                "new_boxes": all_new_bboxes[sl],
+                "scores": all_scores[sl],
+                "image_size": image_size,
+            })
+            cursor += n
+        return results
+
+    # ------------------------------------------------------------------ #
+    @torch.inference_mode()
+    def forward(self, faces_data, batch_data):
+        """Run the multitask model + identity on detected faces; return a
+        per-face DataFrame in original-frame coordinates."""
+        faces = torch.cat([f["faces"] for f in faces_data], dim=0).to(self.device)
+        new_bboxes = torch.cat([f["new_boxes"] for f in faces_data], dim=0).to(self.device)
+        n_faces = faces.shape[0]
+
+        n_per_frame = [f["faces"].shape[0] for f in faces_data]
+        frame_idx = torch.repeat_interleave(
+            torch.arange(len(faces_data), device=self.device),
+            torch.tensor(n_per_frame, device=self.device),
+        )
+        pad_left, pad_top, scale, frame_h, frame_w = per_face_padding_inversion_terms(
+            batch_data, frame_idx, self.device
+        )
+
+        out = self.multitask(faces)  # MultitaskOutput; faces already [0,1] 256 crops
+
+        # ---- AUs (24), emotion (8 softmax), valence/arousal ----
+        feat_aus = pd.DataFrame(out.au, columns=AU_COLUMNS_V2)
+        feat_emotions = pd.DataFrame(out.emotion, columns=EMOTION_COLUMNS_V2)
+        feat_va = pd.DataFrame(
+            np.column_stack([out.valence, out.arousal]), columns=VA_COLUMNS_V2
+        )
+
+        # ---- Identity (ArcFace on the same crops) ----
+        if self.identity_detector is not None and n_faces > 0:
+            emb = self.identity_detector.forward(faces)
+            emb = emb.cpu().detach().numpy() if torch.is_tensor(emb) else np.asarray(emb)
+        else:
+            emb = np.full((n_faces, 512), np.nan)
+        feat_identities = pd.DataFrame(emb, columns=FEAT_IDENTITY_COLUMNS[1:])
+
+        # ---- Faceboxes -> original frame ----
+        bboxes = torch.cat(
+            [convert_bbox_output(f["new_boxes"].to(self.device),
+                                 f["scores"].to(self.device)) for f in faces_data],
+            dim=0,
+        )
+        bboxes[:, 0] = (bboxes[:, 0] - pad_left) / scale
+        bboxes[:, 1] = (bboxes[:, 1] - pad_top) / scale
+        bboxes[:, 2] = bboxes[:, 2] / scale
+        bboxes[:, 3] = bboxes[:, 3] / scale
+        feat_faceboxes = pd.DataFrame(
+            bboxes.cpu().detach().numpy(), columns=FEAT_FACEBOX_COLUMNS
+        )
+
+        # ---- Mesh / landmarks: chip(224) -> [0,1] in 256 crop -> padded
+        #      frame -> original frame. Applied to all 478 vertices; the
+        #      dlib-68 block is a subset for Fex helpers. ----
+        mesh = torch.as_tensor(out.mesh478, device=self.device)   # [N,478,3], 224-px
+        mesh_orig = self._mesh_to_original_frame(
+            mesh, new_bboxes, pad_left, pad_top, scale
+        )                                                          # [N,478,3]
+        lmk68 = mesh_orig[:, self._idx68, :2]                      # [N,68,2]
+
+        feat_landmarks = pd.DataFrame(
+            torch.cat([lmk68[:, :, 0], lmk68[:, :, 1]], dim=1).cpu().numpy(),
+            columns=openface_2d_landmark_columns,
+        )
+        mesh_np = mesh_orig.cpu().numpy()                          # [N,478,3]
+        feat_mesh = pd.DataFrame(
+            np.concatenate([mesh_np[:, :, 0], mesh_np[:, :, 1], mesh_np[:, :, 2]], axis=1),
+            columns=MESH_COLUMNS_V2,
+        )
+
+        # ---- Pose: model [yaw,pitch,roll,tx,ty,tz] -> Fex [Pitch,Roll,Yaw,X,Y,Z] ----
+        p = out.pose
+        feat_poses = pd.DataFrame(
+            np.column_stack([p[:, 1], p[:, 2], p[:, 0], p[:, 3], p[:, 4], p[:, 5]]),
+            columns=FEAT_FACEPOSE_COLUMNS_6D,
+        )
+
+        # ---- Gaze: model [yaw,pitch] rad -> [gaze_pitch,gaze_yaw,gaze_angle] ----
+        gaze_yaw, gaze_pitch = out.gaze[:, 0], out.gaze[:, 1]
+        cos_angle = np.clip(np.cos(gaze_pitch) * np.cos(gaze_yaw), -1.0, 1.0)
+        gaze_angle = np.arccos(cos_angle)
+        feat_gaze = pd.DataFrame(
+            np.column_stack([gaze_pitch, gaze_yaw, gaze_angle]), columns=FEAT_GAZE_COLUMNS
+        )
+
+        feat_frame_meta = pd.DataFrame({
+            "FrameHeight": frame_h.cpu().detach().numpy().astype(np.float64),
+            "FrameWidth": frame_w.cpu().detach().numpy().astype(np.float64),
+        })
+
+        return pd.concat(
+            [feat_faceboxes, feat_landmarks, feat_poses, feat_aus, feat_emotions,
+             feat_va, feat_gaze, feat_identities, feat_mesh, feat_frame_meta],
+            axis=1,
+        )
+
+    def _mesh_to_original_frame(self, mesh, new_bboxes, pad_left, pad_top, scale):
+        """[N,478,3] mesh in 224-chip coords -> original-frame coords.
+
+        x,y go chip(224) -> +offset -> normalize by 256 -> inverse_transform via
+        new_bboxes (padded frame) -> invert DataLoader Rescale. z (relative
+        depth) is passed through unchanged.
+        """
+        N = mesh.shape[0]
+        xy01 = (mesh[:, :, :2] + _CROP_OFFSET) / float(CHIP_SIZE)   # [N,478,2] in [0,1]
+        flat = torch.cat([xy01[:, :, 0], xy01[:, :, 1]], dim=1)     # [N, 2*478] axis-major
+        padded = inverse_transform_landmarks_torch(flat, new_bboxes)  # padded frame
+        padded = padded.reshape(N, 2, N_MESH).permute(0, 2, 1)     # [N,478,2] (x,y)
+        x = (padded[:, :, 0] - pad_left[:, None]) / scale[:, None]
+        y = (padded[:, :, 1] - pad_top[:, None]) / scale[:, None]
+        return torch.stack([x, y, mesh[:, :, 2]], dim=-1)          # [N,478,3]
+
+    # ------------------------------------------------------------------ #
+    def detect(self, inputs, data_type="image", output_size=None, batch_size=1,
+               num_workers=0, pin_memory=False, face_identity_threshold=0.8,
+               face_detection_threshold=None, skip_frames=None, progress_bar=True,
+               **kwargs):
+        """Detect faces + multitask features. Returns a native-v2 Fex."""
+        thr = (face_detection_threshold if face_detection_threshold is not None
+               else self.face_detection_threshold)
+
+        if data_type.lower() == "image":
+            loader = DataLoader(
+                ImageDataset(inputs, output_size=output_size,
+                             preserve_aspect_ratio=True, padding=True),
+                num_workers=num_workers, batch_size=batch_size,
+                pin_memory=pin_memory, shuffle=False)
+        elif data_type.lower() == "tensor":
+            loader = DataLoader(TensorDataset(inputs), batch_size=batch_size,
+                                shuffle=False, num_workers=num_workers,
+                                pin_memory=pin_memory)
+        elif data_type.lower() == "video":
+            dataset = VideoDataset(inputs, skip_frames=skip_frames,
+                                   output_size=output_size)
+            loader = DataLoader(dataset, num_workers=num_workers,
+                                batch_size=batch_size, pin_memory=pin_memory,
+                                shuffle=False)
+        else:
+            raise ValueError(f"unknown data_type {data_type!r}")
+
+        iterator = tqdm(loader) if progress_bar else loader
+        batch_output, frame_counter = [], 0
+        for batch_id, batch_data in enumerate(iterator):
+            faces_data = self.detect_faces(batch_data["Image"],
+                                           face_detection_threshold=thr)
+            batch_results = self.forward(faces_data, batch_data)
+
+            file_names, frame_ids = [], []
+            for i, face in enumerate(faces_data):
+                n = len(face["scores"])
+                fid = (batch_data["Frame"].detach().numpy()[i]
+                       if data_type.lower() == "video" else frame_counter + i)
+                frame_ids.append(np.repeat(fid, n))
+                file_names.append(np.repeat(batch_data["FileName"][i], n))
+            batch_results["input"] = np.concatenate(file_names)
+            batch_results["frame"] = np.concatenate(frame_ids)
+            batch_output.append(batch_results)
+            frame_counter += batch_data["Image"].shape[0]
+
+        concat_df = pd.concat(batch_output).reset_index(drop=True)
+        fex = Fex(
+            concat_df,
+            au_columns=AU_COLUMNS_V2,
+            emotion_columns=EMOTION_COLUMNS_V2,
+            facebox_columns=FEAT_FACEBOX_COLUMNS,
+            landmark_columns=openface_2d_landmark_columns,
+            facepose_columns=FEAT_FACEPOSE_COLUMNS_6D,
+            gaze_columns=FEAT_GAZE_COLUMNS,
+            identity_columns=FEAT_IDENTITY_COLUMNS[1:],
+            detector="Detectorv2",
+            face_model=self.info["face_model"],
+            identity_model=self.info["identity_model"],
+            facepose_model=self.info["facepose_model"],
+            gaze_model=self.info["gaze_model"],
+        )
+        if data_type.lower() == "video":
+            fex["approx_time"] = [dataset.calc_approx_frame_time(x)
+                                  for x in fex["frame"].to_numpy()]
+        fex.compute_identities(threshold=face_identity_threshold, inplace=True)
+        return fex

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -109,51 +109,49 @@ class Detectorv2(nn.Module):
         frames_unit = frames_px / 255.0
 
         rf_outputs = self.face_detector(frames_px)
-        per_image_dets = []
+
+        # Assemble all detections on CPU with numpy, then make exactly ONE
+        # host->device transfer. The prior per-image torch.tensor(..., device=cuda)
+        # + per-frame torch.full/torch.tensor allocations cost ~26ms/batch in
+        # tiny-op + sync overhead; numpy assembly drops that to ~1ms.
+        B = len(rf_outputs)
+        bbox_np, score_np, n_per_frame = [], [], []
         for image_dets in rf_outputs:
             if image_dets:
-                arr = torch.tensor(image_dets, dtype=torch.float32, device=self.device)
-                keep = arr[:, 4] >= face_detection_threshold
-                per_image_dets.append({"boxes": arr[keep, :4], "scores": arr[keep, 4]})
+                arr = np.asarray(image_dets, dtype=np.float32)
+                arr = arr[arr[:, 4] >= face_detection_threshold]
             else:
-                per_image_dets.append({
-                    "boxes": torch.empty((0, 4), device=self.device),
-                    "scores": torch.empty((0,), device=self.device),
-                })
-
-        B = len(per_image_dets)
-        bbox_chunks, score_chunks, n_per_frame = [], [], []
-        for det in per_image_dets:
-            if det["boxes"].numel() != 0:
-                bbox_chunks.append(det["boxes"])
-                score_chunks.append(det["scores"])
-                n_per_frame.append(det["boxes"].shape[0])
-            else:
-                bbox_chunks.append(torch.full((1, 4), float("nan"), device=self.device))
-                score_chunks.append(torch.zeros((1,), device=self.device))
+                arr = np.empty((0, 5), dtype=np.float32)
+            if arr.shape[0] == 0:
+                # No-detection placeholder: one NaN bbox so forward() sees a row.
+                bbox_np.append(np.full((1, 4), np.nan, dtype=np.float32))
+                score_np.append(np.zeros((1,), dtype=np.float32))
                 n_per_frame.append(1)
+            else:
+                bbox_np.append(arr[:, :4])
+                score_np.append(arr[:, 4])
+                n_per_frame.append(arr.shape[0])
 
-        all_bboxes = torch.cat(bbox_chunks, dim=0)
-        all_scores = torch.cat(score_chunks, dim=0)
+        all_bboxes = torch.from_numpy(np.concatenate(bbox_np, axis=0)).to(self.device)
+        all_scores = torch.from_numpy(np.concatenate(score_np, axis=0)).to(self.device)
         n_per_frame_t = torch.tensor(n_per_frame, device=self.device)
         all_frame_idx = torch.repeat_interleave(
             torch.arange(B, device=self.device), n_per_frame_t
         )
 
-        bboxes_for_extract = torch.where(
-            torch.isnan(all_bboxes), torch.zeros_like(all_bboxes), all_bboxes
-        )
+        bboxes_for_extract = torch.nan_to_num(all_bboxes, nan=0.0)
         all_faces, all_new_bboxes = extract_face_from_bbox_torch(
             frames_unit, bboxes_for_extract,
             face_size=self.face_size, expand_bbox=EXPAND_BBOX,
             frame_idx=all_frame_idx,
         )
+        all_new_bboxes = all_new_bboxes.to(torch.float32)
 
         no_det = torch.isnan(all_bboxes).any(dim=1)
         if no_det.any():
             all_faces = all_faces.clone()
             all_faces[no_det] = 0
-            all_new_bboxes = all_new_bboxes.clone().to(torch.float32)
+            all_new_bboxes = all_new_bboxes.clone()
             all_new_bboxes[no_det] = float("nan")
 
         image_size = tuple(frames_unit.shape[-2:])

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -67,7 +67,8 @@ class Detectorv2(nn.Module):
     """
 
     def __init__(self, device="cpu", face_detection_threshold=0.5,
-                 identity_model="arcface", multitask_weights=None, amp=None):
+                 identity_model="arcface", multitask_weights=None, amp=None,
+                 compile=False):
         super().__init__()
         self.device = set_torch_device(device)
         self.face_size = CHIP_SIZE
@@ -75,7 +76,8 @@ class Detectorv2(nn.Module):
 
         self.face_detector = Retinaface(device=self.device)
         self.multitask = MultitaskModel(device=self.device,
-                                        weights_path=multitask_weights, amp=amp)
+                                        weights_path=multitask_weights,
+                                        amp=amp, compile=compile)
         self.identity_detector = (
             ArcFace(backbone="r50") if identity_model == "arcface" else None
         )

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -104,9 +104,9 @@ class Detectorv2(nn.Module):
         call across all faces in the batch, with no-detection frames carrying a
         single NaN-bbox placeholder so forward() sees >= 1 row per frame.
         """
-        frames_unit = convert_image_to_tensor(images, img_type="float32") / 255.0
-        frames_unit = frames_unit.to(self.device)
+        # Convert once on device. RetinaFace wants [0,255]; crops want [0,1].
         frames_px = convert_image_to_tensor(images, img_type="float32").to(self.device)
+        frames_unit = frames_px / 255.0
 
         rf_outputs = self.face_detector(frames_px)
         per_image_dets = []

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -39,7 +39,9 @@ from feat.utils import (
     N_OPENFACE_LANDMARKS,
 )
 from feat.face_detectors.Retinaface.Retinaface_test import Retinaface
-from feat.identity_detectors.arcface.arcface_model import ArcFace
+from feat.identity_detectors.arcface.arcface_model import (
+    load_arcface_identity_detector,
+)
 from feat.multitask import (
     N_MESH,
     AU_COLUMNS_V2,
@@ -79,11 +81,9 @@ class Detectorv2(nn.Module):
                                         weights_path=multitask_weights,
                                         amp=amp, compile=compile)
         self.identity_detector = (
-            ArcFace(backbone="r50") if identity_model == "arcface" else None
+            load_arcface_identity_detector(self.device)
+            if identity_model == "arcface" else None
         )
-        if self.identity_detector is not None:
-            self.identity_detector.to(self.device)
-            self.identity_detector.eval()
 
         self._idx68 = _DLIB68_IDX.to(self.device)
         self.info = dict(

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -12,8 +12,6 @@ training chips were produced; preprocessing to the 224 model input is handled by
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
 import torch
@@ -27,7 +25,6 @@ from feat.utils.image_operations import (
     extract_face_from_bbox_torch,
     convert_image_to_tensor,
     convert_bbox_output,
-    inverse_transform_landmarks_torch,
     per_face_padding_inversion_terms,
 )
 from feat.utils import (
@@ -36,14 +33,12 @@ from feat.utils import (
     FEAT_IDENTITY_COLUMNS,
     FEAT_FACEPOSE_COLUMNS_6D,
     FEAT_GAZE_COLUMNS,
-    N_OPENFACE_LANDMARKS,
 )
 from feat.face_detectors.Retinaface.Retinaface_test import Retinaface
 from feat.identity_detectors.arcface.arcface_model import (
     load_arcface_identity_detector,
 )
 from feat.multitask import (
-    N_MESH,
     AU_COLUMNS_V2,
     EMOTION_COLUMNS_V2,
     VA_COLUMNS_V2,

--- a/feat/identity_detectors/arcface/arcface_model.py
+++ b/feat/identity_detectors/arcface/arcface_model.py
@@ -42,6 +42,8 @@ inherited a similar VGGFace2 research-only restriction, so this is
 not a new license category for py-feat.
 """
 
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -110,3 +112,45 @@ class ArcFace(nn.Module):
         # MPS / CUDA rather than a separate sub + div.
         x = face_crops * 2.0 - 1.0
         return self.net(x)
+
+
+def load_arcface_identity_detector(device, backbone: str = "r50"):
+    """Build an ArcFace detector with the trained w600k_r50 weights loaded.
+
+    ``ArcFace.__init__`` only constructs the architecture (random init), so the
+    embeddings are meaningless until the checkpoint is loaded. Both Detector and
+    Detectorv2 need that load; keep it here as the single source of truth.
+
+    strict=False because BatchNorm's ``num_batches_tracked`` buffer isn't in the
+    converted safetensors (it's absent from the source ONNX). The missing/
+    unexpected keys are validated so a wrong- or empty-file load fails loudly
+    rather than silently producing garbage embeddings.
+    """
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    from feat.utils.io import get_resource_path
+
+    detector = ArcFace(backbone=backbone)
+    arcface_path = os.environ.get("FEAT_ARCFACE_R50_PATH")
+    if arcface_path is None:
+        arcface_path = hf_hub_download(
+            repo_id="py-feat/arcface_r50",
+            filename="arcface_r50.safetensors",
+            cache_dir=get_resource_path(),
+        )
+    missing, unexpected = detector.net.load_state_dict(
+        load_file(arcface_path), strict=False
+    )
+    real_missing = [k for k in missing if "num_batches_tracked" not in k]
+    if real_missing or unexpected:
+        raise RuntimeError(
+            f"ArcFace weights at {arcface_path!r} are inconsistent "
+            f"with the architecture. Missing: {real_missing}; "
+            f"unexpected: {list(unexpected)}. Re-download from "
+            f"py-feat/arcface_r50 or re-run "
+            f"scripts/convert_arcface_onnx_to_safetensors.py."
+        )
+    detector.eval()
+    detector.to(device)
+    return detector

--- a/feat/multitask/BUILD_PLAN.md
+++ b/feat/multitask/BUILD_PLAN.md
@@ -1,0 +1,81 @@
+# Detectorv2 build plan (branch: feat/detector-v2-multitask)
+
+Wire the v2.3 multitask model into py-feat as `Detectorv2`. Pipeline:
+RetinaFace → v2.3 model (AU/emotion/gaze/landmark/pose/VA) + ArcFace identity → Fex.
+
+## Decisions (from user)
+- **Naming:** HARD rename. `Detectorv1` = old pipeline, `Detectorv2` = new. No bare `Detector`.
+- **Output schema:** NATIVE v2 (24 AU, 8 emotion incl. Contempt, V/A, gaze, 6D pose, 478 mesh)
+  PLUS a derived **dlib-68** landmark block from the 478 mesh via py-feat's
+  `DLIB68_FROM_MP478` (feat/utils/blendshape_to_au.py) — so Fex helpers needing 68 points
+  (plotting, PnP pose, alignment) keep working. Any function that needs 68 → feed it the
+  converted 68.
+- **HF:** push to `py-feat/face_multitask_v1` using token in /home/ljchang/Github/py-feat/.env
+  (HF_TOKEN). ROTATE token after session.
+- **Identity:** reuse existing ArcFace (r50) path unchanged.
+- **Detection:** RetinaFace only.
+
+## Preprocessing (MUST match training exactly — verified)
+Training used py-feat's OWN `extract_face_from_bbox_torch`:
+1. RetinaFace detect → bbox [x1,y1,x2,y2]
+2. `extract_face_from_bbox_torch(frame_in_[0,1], bbox, face_size=256, expand_bbox=1.2)` → 256×256
+3. SyncedAugment(train=False): center-crop 256→224, then ImageNet normalize
+   (mean (0.485,0.456,0.406), std (0.229,0.224,0.225)). chip/255 first.
+4. model(chip[B,3,224,224]) → dict
+
+## Model load (from bench_gaze.py:60-84 pattern)
+ckpt=torch.load(path,map_location,weights_only=False); cfg=ModelV2Config(**filtered_config,
+pretrained=False); MEGraphAUv2(cfg).eval(); load_state_dict(ckpt["model"],strict=False).
+Config in ckpt sets use_head_v3=True. Backbone convnextv2_tiny via timm (NEW dep).
+
+## Output decode
+- p_au [B,24] already prob[0,1] → 24 AU cols (AU_NAMES order)
+- emotion_logits [B,8] → softmax → 8 emo cols (Neutral,Happy,Sad,Surprise,Fear,Disgust,Anger,Contempt)
+- va [B,2] in [-1,1] → valence,arousal cols
+- gaze [B,2] radians [yaw,pitch] → gaze cols (+ derived angle)
+- pose [B,6] [yaw,pitch,roll,tx,ty,tz] radians/px
+- mesh [B,478,3] chip-px coords → store 478 + derive dlib-68 block
+- identity [B,512] from ArcFace
+
+## Steps (dependency order)
+1. [ ] ENV: add timm dep; resolve torchcodec import blocker for `import feat`.
+2. [ ] feat/multitask/{model_v2.py,heads_v3.py} vendored (DONE). Add __init__.py.
+3. [ ] feat/multitask/inference.py: MultitaskModel wrapper — load ckpt from HF, preprocess
+       crop→chip, forward, decode to dict. Standalone unit test (no full Detector).
+4. [ ] Repackage inference checkpoint (strip optimizer/EMA/train args; keep model+config) →
+       smoke-test load+forward on feat/tests/data/single_face.jpg; sanity-check outputs.
+5. [ ] Upload checkpoint + model card to py-feat/face_multitask_v1.
+6. [ ] feat/detector.py: Detectorv2 class (RetinaFace → MultitaskModel → ArcFace → Fex
+       native-v2 schema + dlib-68 derived). Loader pulls from HF into resources cache.
+7. [ ] Hard rename Detector→Detectorv1 (update __init__ exports, internal refs). Keep tests.
+8. [ ] Tests: feat/tests/test_detector_v2.py (single/multi face, batch consistency, Fex schema).
+9. [ ] timm in pyproject.toml deps. Model card license notes (ArcFace non-commercial, ConvNeXt).
+
+## Risks
+- Preprocessing mismatch = silent accuracy drop. Mitigated: identical crop fn + verify.
+- torchcodec blocking `import feat` is pre-existing env breakage, not ours.
+- Hard rename breaks existing user code + all tests/docs referencing `Detector` — large blast radius.
+
+## PROGRESS CHECKPOINT (session 2026-05-30)
+
+VERIFIED WORKING (uv env):
+- Dev env = uv: `cd /home/ljchang/Github/py-feat && uv run python ...`. The uv .venv has
+  torch 2.11.0+cu128, feat 0.7.0 (editable -> THIS repo), timm 1.0.27. USE THIS.
+  DO NOT use anaconda base (I broke it pip-installing torchcodec 0.13 incompatible w/ its
+  old torch -> `register_fake` ImportError; `import feat` fails there). au_deep/.venv also
+  works but uv is the project standard now.
+- Branch: feat/detector-v2-multitask (off v0.7-dev).
+- feat/multitask/{model_v2.py, heads_v3.py, __init__.py} vendored. FIX APPLIED: model_v2.py
+  line 575 `from deep.heads_v3` -> `from feat.multitask.heads_v3` (the only deep.* import).
+- Checkpoint loads: ModelV2Config(**filtered_config, pretrained=False) -> MEGraphAUv2 ->
+  load_state_dict(ck["model"], strict=False) => ZERO missing/unexpected. Perfect match.
+- Forward [B,3,224,224] -> dict (CONFIRMED shapes):
+    p_au [B,24] (already prob 0-1), mesh [B,478,3], pose [B,6],
+    emotion_logits [B,8], va [B,2] (valence,arousal tanh -1..1), gaze [B,2] (yaw,pitch rad),
+    cooccur None.
+  (Earlier "va [B,8]" note was WRONG — from a failed build before the import fix. va_head =
+   nn.Linear(in_dim,2). Resolved.)
+- ckpt keys: model, config, stage, epoch, metrics, args. Ship ck["model"].
+
+NEXT: build feat/multitask/inference.py (preprocess crop->chip + forward + decode incl dlib-68
+from 478 mesh via feat.utils.blendshape_to_au.DLIB68_FROM_MP478).

--- a/feat/multitask/MODEL_CARD.md
+++ b/feat/multitask/MODEL_CARD.md
@@ -1,0 +1,72 @@
+---
+license: other
+license_name: research-only
+license_link: LICENSE
+library_name: py-feat
+tags:
+  - facial-expression-analysis
+  - action-units
+  - emotion-recognition
+  - gaze-estimation
+  - face-landmarks
+  - head-pose
+  - multitask
+pipeline_tag: image-classification
+---
+
+# face_multitask_v1
+
+A single multi-task convolutional model for facial behavior analysis, used by
+[py-feat](https://github.com/cosanlab/py-feat)'s `Detectorv2`. From one face crop
+it jointly predicts **action units, categorical emotion, valence/arousal,
+eye gaze, a 478-point face mesh, and 6-DoF head pose**.
+
+- **Backbone:** ConvNeXt-V2 Tiny (FCMAE + IN-22k/IN-1k pretrained)
+- **Heads:** ME-GraphAU AU graph (AFG/FGG/MEFL/SC) + unified-feature emotion/V-A
+  and gaze heads (v2.3 architecture) + landmark and pose regression heads
+- **Params:** ~30M · **Input:** 224×224 RGB (from a 256×256 face crop) · **File:** `face_multitask_v1.pt` (174 MB)
+
+## Outputs
+
+| Task | Output | Notes |
+|---|---|---|
+| Action Units | 24 probabilities [0,1] | AU01,02,04,05,06,07,09,10,11,12,14,15,16,17,18,20,23,24,25,26,27,28,43,45 |
+| Emotion | 8-class softmax | Neutral, Happy, Sad, Surprise, Fear, Disgust, Anger, Contempt |
+| Valence / Arousal | 2 × [−1,1] | tanh |
+| Gaze | (yaw, pitch) radians | head-centric; yaw+ = right, pitch+ = up |
+| Face mesh | 478 × (x,y,z) | MediaPipe topology, chip-pixel coords (z = relative depth) |
+| Head pose | (yaw, pitch, roll, tx, ty, tz) | radians / pixels |
+| 68 landmarks | derived | dlib-68 subset sampled from the 478 mesh |
+
+## Benchmarks (held-out, file-verified)
+
+| Task | Dataset | Metric | Score |
+|---|---|---|---|
+| AU | DISFA+ (12-AU, Cheong protocol) | macro-F1 | **0.679** |
+| Emotion | RAF-DB official test (7-cls) | acc / macro-F1 | **0.839 / 0.751** |
+| Emotion | AffectNet val (7-cls, drop Contempt) | acc / macro-F1 | 0.304 / 0.264 |
+| Valence/Arousal | Aff-Wild2 official validation | CCC (V / A) | **0.788 / 0.736** |
+| Gaze | MPIIGaze | mean angular err | **3.33°** |
+| Gaze | Gaze360 | mean angular err | **5.81°** |
+
+Notes: emotion is strong on RAF-DB / Aff-Wild2 but weaker on AffectNet
+(label noise + class imbalance); AffectNet-specific, not architectural.
+
+## Usage
+
+```python
+from feat import Detectorv2
+detector = Detectorv2(device="cuda")
+fex = detector.detect("image.jpg")   # returns a py-feat Fex
+```
+
+The model expects a face crop produced by RetinaFace + py-feat's
+`extract_face_from_bbox_torch(frame, bbox, face_size=256, expand_bbox=1.2)`,
+then center-cropped to 224 and ImageNet-normalized. `Detectorv2` handles this.
+
+## License
+
+**Research / non-commercial use only.** Trained on datasets (AffectNet, DISFA+,
+RAF-DB, Aff-Wild2, BP4D, etc.) whose licenses restrict use to academic research.
+The ConvNeXt-V2 backbone is MIT-licensed. Confirm each constituent dataset's
+terms before any non-research use.

--- a/feat/multitask/__init__.py
+++ b/feat/multitask/__init__.py
@@ -11,10 +11,25 @@ from feat.multitask.model_v2 import (
     ModelV2Config,
 )
 
+# Emotion class order emitted by the v2.3 head (NOT the v1 lowercase order).
 EMOTION_NAMES = [
     "Neutral", "Happy", "Sad", "Surprise",
     "Fear", "Disgust", "Anger", "Contempt",
 ]
+
+# --- Native-v2 Fex column schema ---
+# AUs: 24 columns, names already "AU01".."AU45".
+AU_COLUMNS_V2 = list(AU_NAMES)
+# Emotion: 8 columns (includes Contempt, unlike v1's 7).
+EMOTION_COLUMNS_V2 = list(EMOTION_NAMES)
+# Valence / arousal regression (continuous, [-1, 1]).
+VA_COLUMNS_V2 = ["valence", "arousal"]
+# 478-point MediaPipe mesh in original-frame coords (x,y) + relative depth (z).
+MESH_COLUMNS_V2 = (
+    [f"mesh_x_{i}" for i in range(N_MESH)]
+    + [f"mesh_y_{i}" for i in range(N_MESH)]
+    + [f"mesh_z_{i}" for i in range(N_MESH)]
+)
 
 __all__ = [
     "AU_NAMES",
@@ -24,4 +39,8 @@ __all__ = [
     "N_MESH",
     "MEGraphAUv2",
     "ModelV2Config",
+    "AU_COLUMNS_V2",
+    "EMOTION_COLUMNS_V2",
+    "VA_COLUMNS_V2",
+    "MESH_COLUMNS_V2",
 ]

--- a/feat/multitask/__init__.py
+++ b/feat/multitask/__init__.py
@@ -1,0 +1,27 @@
+"""Multitask v2 model (ConvNeXt-V2 backbone; AU + emotion + V/A + gaze + landmark + pose).
+
+Vendored from the au_deep training repo for inference inside py-feat's Detectorv2.
+"""
+from feat.multitask.model_v2 import (
+    AU_NAMES,
+    N_AU,
+    N_EMOTION,
+    N_MESH,
+    MEGraphAUv2,
+    ModelV2Config,
+)
+
+EMOTION_NAMES = [
+    "Neutral", "Happy", "Sad", "Surprise",
+    "Fear", "Disgust", "Anger", "Contempt",
+]
+
+__all__ = [
+    "AU_NAMES",
+    "EMOTION_NAMES",
+    "N_AU",
+    "N_EMOTION",
+    "N_MESH",
+    "MEGraphAUv2",
+    "ModelV2Config",
+]

--- a/feat/multitask/heads_v3.py
+++ b/feat/multitask/heads_v3.py
@@ -1,0 +1,113 @@
+"""v2.3 head architectures.
+
+Design (OpenFace 3 inspired + lessons from v2.2):
+  - Unified features = (backbone GAP) ∥ (projected mesh x,y coords)
+    → gives heads direct access to landmark geometry without backbone
+       needing to encode it
+  - GazeHeadV3: 4 FCs (left/right × yaw/pitch), L2CS-Net pattern,
+       no eye cross-attention (landmarks already in input)
+  - EmotionVAHeadV3: linear 8-way classifier + linear V/A regressor,
+       no AU-node attention (avoids v2's AU04-degenerate routing)
+  - Cooccurrence head DROPPED entirely (BP4D-skewed priors hurt DISFA+
+       transfer in v2 stage 3)
+
+Drop z from mesh: MediaPipe z is depth-rank not metric depth (noisier),
+and emotion/gaze are determined by x,y geometry of mouth/brow/eye
+contours which are already in 2D. Saves ~30% of proj_lmk params.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+N_MESH = 478
+
+
+class UnifiedFeatures(nn.Module):
+    """Builds the unified feature vector for all v3 heads.
+
+    unified = cat( backbone_GAP[B, bb_ch],  proj_lmk(mesh_xy/image_size)[B, lmk_dim] )
+
+    Mesh coords are normalized by image_size before projection — without
+    this, lmk_feat magnitude (~65) dominates and downstream tanh/softmax
+    saturate, killing V/A and emotion learning.
+
+    Args:
+      bb_ch: backbone output channels (768 for ConvNeXt v2 Tiny)
+      lmk_dim: projected landmark feature dim (256)
+      image_size: input image size in pixels (224); mesh coords assumed
+        to be in [0, image_size] before normalization
+    Forward:
+      X_bb: backbone features [B, bb_ch, H, W]
+      mesh: predicted mesh [B, N_MESH, 3]  (we ignore the z dim)
+    Returns:
+      unified: [B, bb_ch + lmk_dim]
+    """
+
+    def __init__(self, bb_ch: int = 768, lmk_dim: int = 256, image_size: int = 224):
+        super().__init__()
+        self.bb_ch = bb_ch
+        self.lmk_dim = lmk_dim
+        self.out_dim = bb_ch + lmk_dim
+        self.image_size = float(image_size)
+        # 478 landmarks × 2 (x,y) = 956 input dims
+        self.proj_lmk = nn.Linear(N_MESH * 2, lmk_dim)
+        # LayerNorm on each component before concatenation. Without this,
+        # ConvNeXt v2 backbone GAP can have std~8 and ranges in the
+        # hundreds; downstream tanh/softmax saturate, killing learning.
+        self.norm_bb = nn.LayerNorm(bb_ch)
+        self.norm_lmk = nn.LayerNorm(lmk_dim)
+
+    def forward(self, X_bb: torch.Tensor, mesh: torch.Tensor) -> torch.Tensor:
+        # Backbone GAP — [B, bb_ch, H, W] -> [B, bb_ch]
+        bb_gap = X_bb.mean(dim=(-2, -1))
+        # Mesh x,y — [B, 478, 3] -> [B, 956]. Normalize pixel coords to ~[0,1].
+        B = mesh.shape[0]
+        mesh_xy = mesh[:, :, :2].reshape(B, N_MESH * 2) / self.image_size
+        lmk_feat = self.proj_lmk(mesh_xy)
+        # LayerNorm each component so neither dominates the unified vector
+        return torch.cat([self.norm_bb(bb_gap), self.norm_lmk(lmk_feat)], dim=-1)
+
+
+class GazeHeadV3(nn.Module):
+    """L2CS-Net style: 4 independent FCs for left/right × yaw/pitch.
+
+    Aggregate per-axis by mean of left + right (could also concat both
+    into the final gaze output for downstream eye-divergence analysis;
+    keeping mean to match v2 interface that returns [B, 2] = [yaw, pitch]).
+    """
+
+    def __init__(self, in_dim: int):
+        super().__init__()
+        self.left_yaw   = nn.Linear(in_dim, 1)
+        self.left_pitch = nn.Linear(in_dim, 1)
+        self.right_yaw  = nn.Linear(in_dim, 1)
+        self.right_pitch = nn.Linear(in_dim, 1)
+
+    def forward(self, unified: torch.Tensor) -> torch.Tensor:
+        yaw   = 0.5 * (self.left_yaw(unified)   + self.right_yaw(unified))
+        pitch = 0.5 * (self.left_pitch(unified) + self.right_pitch(unified))
+        return torch.cat([yaw, pitch], dim=-1)   # [B, 2]
+
+
+class EmotionVAHeadV3(nn.Module):
+    """Linear 8-way classifier + linear V/A regressor from unified features.
+
+    Returns dict with same keys as v2 EmotionVAHead so the training loop
+    doesn't need to special-case.
+    """
+
+    def __init__(self, in_dim: int, n_classes: int = 8, dropout: float = 0.2):
+        super().__init__()
+        self.dropout = nn.Dropout(dropout)
+        self.cls_head = nn.Linear(in_dim, n_classes)
+        self.va_head  = nn.Linear(in_dim, 2)
+
+    def forward(self, unified: torch.Tensor) -> dict:
+        u = self.dropout(unified)
+        return {
+            "emotion_logits": self.cls_head(u),
+            # V/A in [-1, 1] via tanh — matches v2 convention
+            "va": torch.tanh(self.va_head(u)),
+        }

--- a/feat/multitask/inference.py
+++ b/feat/multitask/inference.py
@@ -1,0 +1,122 @@
+"""Inference wrapper for the v2.3 multitask model inside py-feat.
+
+Loads the checkpoint from the HuggingFace hub (``py-feat/face_multitask_v1``),
+preprocesses RetinaFace face crops into model chips *exactly* as training did,
+runs a forward pass, and decodes the raw output dict into labelled arrays.
+
+Preprocessing contract (must match training — deep/augment.py SyncedAugment,
+train=False): a 256x256 uint8 RGB chip -> /255 -> center-crop to 224 ->
+ImageNet normalize. The chip itself is produced upstream by
+``extract_face_from_bbox_torch(frame_in_[0,1], bbox, face_size=256,
+expand_bbox=1.2)`` — the same py-feat helper training used.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torchvision.transforms.v2.functional as TF
+
+from feat.multitask.model_v2 import MEGraphAUv2, ModelV2Config, AU_NAMES, N_MESH
+from feat.multitask import EMOTION_NAMES
+from feat.utils.blendshape_to_au import DLIB68_FROM_MP478
+
+# Chip geometry — fixed by how training chips were produced.
+CHIP_SIZE = 256          # extract_face_from_bbox_torch face_size
+MODEL_INPUT = 224        # model image_size (center-crop of the chip)
+EXPAND_BBOX = 1.2        # bbox margin multiplier used at extraction
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+HF_REPO = "py-feat/face_multitask_v1"
+HF_WEIGHTS_FILE = "face_multitask_v1.pt"
+
+# dlib-68 vertex indices into the MediaPipe-478 mesh (py-feat canonical map).
+_DLIB68_IDX = torch.tensor(DLIB68_FROM_MP478, dtype=torch.long)
+
+
+@dataclass
+class MultitaskOutput:
+    """Decoded, labelled model output for a batch of N faces."""
+    au: np.ndarray              # [N, 24] probabilities in [0, 1]
+    au_names: list              # 24 AU names
+    emotion: np.ndarray         # [N, 8] softmax probabilities
+    emotion_names: list         # 8 emotion names
+    valence: np.ndarray         # [N] in [-1, 1]
+    arousal: np.ndarray         # [N] in [-1, 1]
+    gaze: np.ndarray            # [N, 2] (yaw, pitch) radians
+    pose: np.ndarray            # [N, 6] (yaw, pitch, roll, tx, ty, tz)
+    mesh478: np.ndarray         # [N, 478, 3] chip-pixel coords (224 space)
+    landmarks68: np.ndarray     # [N, 68, 2] dlib-68 (x, y) sampled from mesh478
+
+
+class MultitaskModel:
+    """Loads + runs the v2.3 multitask model. Detection-agnostic: it consumes
+    256x256 face chips and returns decoded predictions."""
+
+    def __init__(self, device="cpu", weights_path=None):
+        self.device = torch.device(device)
+        ckpt = torch.load(self._resolve_weights(weights_path),
+                          map_location=self.device, weights_only=False)
+        saved_cfg = ckpt["config"]
+        valid = set(ModelV2Config.__dataclass_fields__.keys())
+        filtered = {k: v for k, v in saved_cfg.items()
+                    if k in valid and k not in ("pretrained", "use_head_v2")}
+        cfg = ModelV2Config(**filtered, pretrained=False,
+                            use_head_v2=saved_cfg.get("use_head_v2", False))
+        self.cfg = cfg
+        model = MEGraphAUv2(cfg)
+        missing, unexpected = model.load_state_dict(ckpt["model"], strict=False)
+        if missing or unexpected:
+            raise RuntimeError(
+                f"multitask checkpoint mismatch: {len(missing)} missing, "
+                f"{len(unexpected)} unexpected keys")
+        self.model = model.to(self.device).eval()
+        self._mean = torch.tensor(IMAGENET_MEAN, device=self.device).view(3, 1, 1)
+        self._std = torch.tensor(IMAGENET_STD, device=self.device).view(3, 1, 1)
+        self._idx68 = _DLIB68_IDX.to(self.device)
+
+    @staticmethod
+    def _resolve_weights(weights_path):
+        if weights_path is not None:
+            return weights_path
+        from huggingface_hub import hf_hub_download
+        from feat.utils.io import get_resource_path
+        return hf_hub_download(repo_id=HF_REPO, filename=HF_WEIGHTS_FILE,
+                               cache_dir=get_resource_path())
+
+    def preprocess(self, chips):
+        """chips: [N, 3, 256, 256] float in [0, 1] (RetinaFace crops).
+        Returns [N, 3, 224, 224] ImageNet-normalized model input."""
+        chips = chips.to(self.device)
+        if chips.shape[-1] != CHIP_SIZE:
+            chips = F.interpolate(chips, size=(CHIP_SIZE, CHIP_SIZE),
+                                  mode="bilinear", align_corners=False)
+        chips = TF.center_crop(chips, [MODEL_INPUT, MODEL_INPUT])
+        return (chips - self._mean) / self._std
+
+    @torch.inference_mode()
+    def __call__(self, chips):
+        """chips: [N, 3, 256, 256] float in [0, 1]. Returns MultitaskOutput."""
+        x = self.preprocess(chips)
+        out = self.model(x)
+
+        emotion = F.softmax(out["emotion_logits"], dim=-1)
+        va = out["va"]
+        mesh = out["mesh"]                      # [N, 478, 3] in 224-px coords
+        lmk68 = mesh[:, self._idx68, :2]        # [N, 68, 2]
+
+        return MultitaskOutput(
+            au=out["p_au"].float().cpu().numpy(),
+            au_names=list(AU_NAMES),
+            emotion=emotion.float().cpu().numpy(),
+            emotion_names=list(EMOTION_NAMES),
+            valence=va[:, 0].float().cpu().numpy(),
+            arousal=va[:, 1].float().cpu().numpy(),
+            gaze=out["gaze"].float().cpu().numpy(),
+            pose=out["pose"].float().cpu().numpy(),
+            mesh478=mesh.float().cpu().numpy(),
+            landmarks68=lmk68.float().cpu().numpy(),
+        )

--- a/feat/multitask/inference.py
+++ b/feat/multitask/inference.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn.functional as F
 import torchvision.transforms.v2.functional as TF
 
-from feat.multitask.model_v2 import MEGraphAUv2, ModelV2Config, AU_NAMES, N_MESH
+from feat.multitask.model_v2 import MEGraphAUv2, ModelV2Config, AU_NAMES
 from feat.multitask import EMOTION_NAMES
 from feat.utils.blendshape_to_au import DLIB68_FROM_MP478
 

--- a/feat/multitask/inference.py
+++ b/feat/multitask/inference.py
@@ -56,8 +56,13 @@ class MultitaskModel:
     """Loads + runs the v2.3 multitask model. Detection-agnostic: it consumes
     256x256 face chips and returns decoded predictions."""
 
-    def __init__(self, device="cpu", weights_path=None):
+    def __init__(self, device="cpu", weights_path=None, amp=None):
         self.device = torch.device(device)
+        # Mixed precision: the model was trained with bf16 autocast, and bf16
+        # inference matches fp32 to within model noise (AU <0.01, gaze <0.03 deg)
+        # while running ~3x faster on GPU. Default on for CUDA, off on CPU
+        # (CPU autocast is slow/uneven for these ops). Pass amp=False to force fp32.
+        self.amp = (self.device.type == "cuda") if amp is None else amp
         ckpt = torch.load(self._resolve_weights(weights_path),
                           map_location=self.device, weights_only=False)
         saved_cfg = ckpt["config"]
@@ -101,7 +106,11 @@ class MultitaskModel:
     def __call__(self, chips):
         """chips: [N, 3, 256, 256] float in [0, 1]. Returns MultitaskOutput."""
         x = self.preprocess(chips)
-        out = self.model(x)
+        if self.amp:
+            with torch.autocast(self.device.type, dtype=torch.bfloat16):
+                out = self.model(x)
+        else:
+            out = self.model(x)
 
         emotion = F.softmax(out["emotion_logits"], dim=-1)
         va = out["va"]

--- a/feat/multitask/inference.py
+++ b/feat/multitask/inference.py
@@ -56,13 +56,18 @@ class MultitaskModel:
     """Loads + runs the v2.3 multitask model. Detection-agnostic: it consumes
     256x256 face chips and returns decoded predictions."""
 
-    def __init__(self, device="cpu", weights_path=None, amp=None):
+    def __init__(self, device="cpu", weights_path=None, amp=None, compile=False):
         self.device = torch.device(device)
         # Mixed precision: the model was trained with bf16 autocast, and bf16
         # inference matches fp32 to within model noise (AU <0.01, gaze <0.03 deg)
         # while running ~3x faster on GPU. Default on for CUDA, off on CPU
         # (CPU autocast is slow/uneven for these ops). Pass amp=False to force fp32.
         self.amp = (self.device.type == "cuda") if amp is None else amp
+        # torch.compile gives a further ~3x on CUDA (the MEFL edge loop fuses
+        # well), AU max-diff ~8e-4 vs eager. Off by default: the first call pays
+        # a multi-second compile and each new batch size recompiles, which is a
+        # footgun for interactive use. Turn on for batch/throughput jobs.
+        self.compile = compile
         ckpt = torch.load(self._resolve_weights(weights_path),
                           map_location=self.device, weights_only=False)
         saved_cfg = ckpt["config"]
@@ -79,6 +84,8 @@ class MultitaskModel:
                 f"multitask checkpoint mismatch: {len(missing)} missing, "
                 f"{len(unexpected)} unexpected keys")
         self.model = model.to(self.device).eval()
+        if self.compile:
+            self.model = torch.compile(self.model)
         self._mean = torch.tensor(IMAGENET_MEAN, device=self.device).view(3, 1, 1)
         self._std = torch.tensor(IMAGENET_STD, device=self.device).view(3, 1, 1)
         self._idx68 = _DLIB68_IDX.to(self.device)

--- a/feat/multitask/inference.py
+++ b/feat/multitask/inference.py
@@ -63,10 +63,12 @@ class MultitaskModel:
         # while running ~3x faster on GPU. Default on for CUDA, off on CPU
         # (CPU autocast is slow/uneven for these ops). Pass amp=False to force fp32.
         self.amp = (self.device.type == "cuda") if amp is None else amp
-        # torch.compile gives a further ~3x on CUDA (the MEFL edge loop fuses
-        # well), AU max-diff ~8e-4 vs eager. Off by default: the first call pays
-        # a multi-second compile and each new batch size recompiles, which is a
-        # footgun for interactive use. Turn on for batch/throughput jobs.
+        # torch.compile fuses the MEFL edge loop for ~1.7x on the model forward
+        # (90->53ms on Blackwell, batch 80). Off by default: (a) the first call
+        # pays multi-second compile and each new batch size recompiles, a footgun
+        # for interactive use; (b) compiled-vs-eager AU output diverges ~0.16 in
+        # default mode under bf16 autocast — not yet validated as safe. Enable
+        # only for throughput jobs where that drift has been checked acceptable.
         self.compile = compile
         ckpt = torch.load(self._resolve_weights(weights_path),
                           map_location=self.device, weights_only=False)

--- a/feat/multitask/model_v2.py
+++ b/feat/multitask/model_v2.py
@@ -1,0 +1,671 @@
+"""ME-GraphAU v2 — multi-task face detector for py-feat.
+
+Key differences from v1 (model.py):
+  - ConvNeXt v2 Tiny backbone (FCMAE+IN22k pretrained, +1.4% IN-1k vs v1)
+  - 24 AUs (added AU16, 18, 27, 45)
+  - EmotionVAHead — 8-class emotion + V/A regression
+  - GazeHead — eye-region landmark cross-attention + AU-eye gating + dual-eye 2-node GCN
+  - MEFL identity-init (FAM/ARM output projection zero) to eliminate v1's
+    stage-3 transition shock
+
+All other modules (AFG, FGG, MEFL graph topology, LandmarkHead, PoseHead,
+SCHead, CooccurrenceHead) carry over from v1.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import timm
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# 24 AUs for v2 (v1's 20 + AU16, AU18, AU27, AU45)
+AU_NAMES = [
+    "AU01", "AU02", "AU04", "AU05", "AU06", "AU07", "AU09", "AU10",
+    "AU11", "AU12", "AU14", "AU15", "AU16", "AU17", "AU18", "AU20",
+    "AU23", "AU24", "AU25", "AU26", "AU27", "AU28", "AU43", "AU45",
+]
+N_AU = 24
+N_MESH = 478
+N_EMOTION = 8     # Neutral, Happy, Sad, Surprise, Fear, Disgust, Anger, Contempt
+
+# MediaPipe 478 mesh: eye-region vertex indices for the GazeHead.
+# Conservative set: eyelid contours + iris (10 vertices total) per eye.
+MP_LEFT_EYE_IDX = list(range(33, 47)) + list(range(133, 145)) + list(range(469, 473))
+MP_RIGHT_EYE_IDX = list(range(263, 277)) + list(range(362, 374)) + list(range(473, 477))
+
+# AU indices that gate gaze (eye-related AUs in our 24-AU set)
+# AU05 idx=3, AU07 idx=5, AU09 idx=6, AU43 idx=22, AU45 idx=23
+GAZE_GATE_AU_IDX = [3, 5, 6, 22, 23]
+
+
+@dataclass
+class ModelV2Config:
+    backbone: str = "convnextv2_tiny.fcmae_ft_in22k_in1k"
+    image_size: int = 224
+    n_au: int = N_AU
+    n_mesh: int = N_MESH
+    n_emotion: int = N_EMOTION
+    knn_k: int = 4
+    afg_channels: int = 512
+    mefl_channels: int = 512
+    gcn_layers: int = 2
+    drop_path_rate: float = 0.1
+    pretrained: bool = True
+    emotion_head_dropout: float = 0.25
+    use_dual_eye_gcn: bool = True
+    mefl_identity_init: bool = False  # legacy; kept for ckpt-cfg back-compat
+    mefl_use_layer_scale: bool = True  # gate MEFL contribution via α (init 1e-2)
+    use_head_v2: bool = False   # v2.1: enables EmotionVAHeadV2 + GazeHeadV2
+    use_head_v3: bool = False   # v2.3: unified features + simpler heads, drops cooccur
+    unified_lmk_dim: int = 256  # v2.3: projected landmark feature dim
+                                #   - EmotionVAHeadV2: stronger backbone GAP path + 2-trunk fusion
+                                #   - GazeHeadV2: backbone GAP + landmark cross-attn, NO AU gating,
+                                #     separate yaw/pitch heads (L2CS-Net pattern)
+
+
+# ============================ ANFL (unchanged from v1) ============================
+
+class AFG(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, n_au: int):
+        super().__init__()
+        self.n_au = n_au
+        self.heads = nn.ModuleList([
+            nn.Sequential(
+                nn.Conv2d(in_ch, out_ch, kernel_size=1, bias=False),
+                nn.BatchNorm2d(out_ch),
+                nn.ReLU(inplace=True),
+            )
+            for _ in range(n_au)
+        ])
+
+    def forward(self, x: torch.Tensor):
+        U_list = [head(x) for head in self.heads]
+        U = torch.stack(U_list, dim=1)
+        v = U.mean(dim=(-2, -1))
+        return U, v
+
+
+class FGG(nn.Module):
+    def __init__(self, ch: int, k: int):
+        super().__init__()
+        self.k = k
+        self.W = nn.Linear(ch, ch, bias=False)
+        self.W_self = nn.Linear(ch, ch, bias=False)
+
+    def forward(self, v: torch.Tensor) -> torch.Tensor:
+        B, N, C = v.shape
+        v_norm = F.normalize(v, dim=-1)
+        sim = torch.bmm(v_norm, v_norm.transpose(1, 2))
+        topk = sim.topk(self.k + 1, dim=-1).indices
+        adj = torch.zeros_like(sim)
+        adj.scatter_(2, topk, 1.0)
+        eye = torch.eye(N, device=v.device).unsqueeze(0)
+        adj = adj * (1 - eye)
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        adj = adj / deg
+        msg = self.W(v)
+        agg = torch.bmm(adj, msg)
+        out = F.relu(self.W_self(v) + agg)
+        return out
+
+
+# ============================ MEFL (with identity-init for v2) ============================
+
+class CrossAttention(nn.Module):
+    """Cross-attention with Kaiming-normal init (matches original ME-GraphAU
+    paper, model/graph_edge_model.py).
+
+    NOTE: The v2-original `zero_init_output=True` path created a dead fixed
+    point — proj=0 zeroes ∂L/∂(q,k,v) (chain rule), so q/k/v stayed at init
+    and proj never moved off zero (weight decay dragged it back faster than
+    the tiny ∂L/∂proj could grow it). Diagnosed in
+    analysis/v2/diag/FINDINGS.md. Now using normal init; MEFL contribution
+    is ramped in smoothly via the LayerScale α in MEFL.forward."""
+
+    def __init__(self, ch: int, heads: int = 4):
+        super().__init__()
+        self.heads = heads
+        self.scale = (ch // heads) ** -0.5
+        self.q = nn.Conv2d(ch, ch, 1, bias=False)
+        self.k = nn.Conv2d(ch, ch, 1, bias=False)
+        self.v = nn.Conv2d(ch, ch, 1, bias=False)
+        self.proj = nn.Conv2d(ch, ch, 1, bias=False)
+        # PyTorch's default Kaiming-uniform on Conv2d is fine — no override.
+
+    def forward(self, q_in: torch.Tensor, kv_in: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = q_in.shape
+        Q = self.q(q_in).view(B, self.heads, C // self.heads, H * W)
+        K = self.k(kv_in).view(B, self.heads, C // self.heads, H * W)
+        V = self.v(kv_in).view(B, self.heads, C // self.heads, H * W)
+        attn = torch.einsum("bhdn,bhdm->bhnm", Q, K) * self.scale
+        attn = attn.softmax(dim=-1)
+        out = torch.einsum("bhnm,bhdm->bhdn", attn, V)
+        out = out.reshape(B, C, H, W)
+        return self.proj(out)
+
+
+class GatedGCNLayer(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.U = nn.Linear(ch, ch)
+        self.V = nn.Linear(ch, ch)
+        self.A = nn.Linear(ch, ch)
+        self.B = nn.Linear(ch, ch)
+        self.C = nn.Linear(ch, ch)
+        self.ln_h = nn.LayerNorm(ch)
+        self.ln_e = nn.LayerNorm(ch)
+
+    def forward(self, h: torch.Tensor, e: torch.Tensor):
+        B, N, C = h.shape
+        Ah = self.A(h).unsqueeze(2).expand(-1, -1, N, -1)
+        Bh = self.B(h).unsqueeze(1).expand(-1, N, -1, -1)
+        Ce = self.C(e)
+        e_msg = F.relu(self.ln_e(Ah + Bh + Ce))
+        e_new = e + e_msg
+        sigmoid_e = torch.sigmoid(e_new)
+        Vh = self.V(h).unsqueeze(1).expand(-1, N, -1, -1)
+        aggregated = (sigmoid_e * Vh).sum(dim=2)
+        Uh = self.U(h)
+        h_msg = F.relu(self.ln_h(Uh + aggregated))
+        h_new = h + h_msg
+        return h_new, e_new
+
+
+class MEFL(nn.Module):
+    """Multi-dim Edge Feature Learning (Luo et al. IJCAI 2022).
+
+    FAM/ARM use Kaiming-normal init (paper convention). A LayerScale α
+    (init=0.01, no weight decay) gates MEFL's contribution into the edge
+    tensor so we ramp smoothly without the v2-era identity-init dead trap.
+    Set use_layer_scale=False to recover the paper-exact behavior.
+    """
+
+    def __init__(self, ch: int, n_au: int, gcn_layers: int,
+                 use_layer_scale: bool = True, layer_scale_init: float = 1e-2):
+        super().__init__()
+        self.n_au = n_au
+        self.fam = CrossAttention(ch, heads=4)
+        self.arm = CrossAttention(ch, heads=4)
+        self.gcn = nn.ModuleList([GatedGCNLayer(ch) for _ in range(gcn_layers)])
+        self.use_layer_scale = use_layer_scale
+        if use_layer_scale:
+            # Single learnable scalar α per CrossAttention output. α starts at
+            # 0.01 (MEFL contributes ~1% at init), grows under gradient if
+            # MEFL helps. Excluded from weight decay (see train_v2_stage3.py).
+            self.alpha_fam = nn.Parameter(torch.full((), layer_scale_init))
+            self.alpha_arm = nn.Parameter(torch.full((), layer_scale_init))
+
+    def reinit_proj(self, std_fan_in: bool = True):
+        """Re-initialize FAM/ARM proj weights with Kaiming-normal.
+        Call after loading a stage-2 checkpoint where these were zeroed by
+        the legacy identity-init path."""
+        for m in (self.fam, self.arm):
+            ch = m.proj.weight.shape[0]
+            fan_in = ch  # 1x1 conv
+            std = math.sqrt(2.0 / fan_in) if std_fan_in else 0.02
+            nn.init.normal_(m.proj.weight, mean=0.0, std=std)
+            # Also re-init q/k/v if they're at PyTorch's default (they will
+            # have been stuck at init since proj=0 killed gradient to them).
+            for sub in (m.q, m.k, m.v):
+                nn.init.normal_(sub.weight, mean=0.0, std=std)
+
+    def forward(self, U: torch.Tensor, X: torch.Tensor, v_fgg: torch.Tensor):
+        B, N, C, H, W = U.shape
+        U_flat = U.reshape(B * N, C, H, W)
+        X_rep = X.unsqueeze(1).expand(-1, N, -1, -1, -1).reshape(B * N, C, H, W)
+        F_AS = self.fam(U_flat, X_rep)
+        if self.use_layer_scale:
+            F_AS = self.alpha_fam * F_AS
+        F_AS = F_AS.reshape(B, N, C, H, W)
+
+        e = torch.zeros(B, N, N, C, device=U.device, dtype=U.dtype)
+        for i in range(N):
+            Fi = F_AS[:, i].unsqueeze(1).expand(-1, N, -1, -1, -1).reshape(B * N, C, H, W)
+            Fj = F_AS.reshape(B * N, C, H, W)
+            F_AR = self.arm(Fj, Fi)
+            if self.use_layer_scale:
+                F_AR = self.alpha_arm * F_AR
+            e_i = F_AR.mean(dim=(-2, -1)).view(B, N, C)
+            e[:, i, :, :] = e_i
+
+        h = v_fgg
+        for layer in self.gcn:
+            h, e = layer(h, e)
+        return h, e
+
+
+# ============================ Heads ============================
+
+class SCHead(nn.Module):
+    """Per-AU presence prob via cosine similarity to learnable prototypes."""
+
+    def __init__(self, n_au: int, ch: int):
+        super().__init__()
+        self.s = nn.Parameter(torch.randn(n_au, ch) * 0.02)
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        s = F.relu(self.s)
+        h = F.relu(h)
+        h_norm = F.normalize(h, dim=-1)
+        s_norm = F.normalize(s, dim=-1)
+        cos = (h_norm * s_norm.unsqueeze(0)).sum(dim=-1)
+        return cos.clamp(0.0, 1.0)
+
+
+class CooccurrenceHead(nn.Module):
+    def __init__(self, ch: int, n_classes: int = 4):
+        super().__init__()
+        self.fc = nn.Sequential(
+            nn.Linear(2 * ch, ch),
+            nn.ReLU(inplace=True),
+            nn.Linear(ch, n_classes),
+        )
+
+    def forward(self, e: torch.Tensor) -> torch.Tensor:
+        e_concat = torch.cat([e, e.transpose(1, 2)], dim=-1)
+        return self.fc(e_concat)
+
+
+class LandmarkHead(nn.Module):
+    def __init__(self, in_ch: int, out: int = N_MESH * 3, hidden: int = 1024):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(in_ch, hidden), nn.GELU(),
+            nn.Linear(hidden, hidden), nn.GELU(),
+            nn.Linear(hidden, out),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z = x.mean(dim=(-2, -1))
+        return self.mlp(z).view(-1, N_MESH, 3)
+
+
+class PoseHead(nn.Module):
+    def __init__(self, in_ch: int, out: int = 6, hidden: int = 256):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(in_ch, hidden), nn.GELU(),
+            nn.Linear(hidden, hidden), nn.GELU(),
+            nn.Linear(hidden, out),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.mlp(x.mean(dim=(-2, -1)))
+
+
+class EmotionVAHead(nn.Module):
+    """Emotion classification + valence/arousal regression.
+
+    Reads MEFL's refined per-AU node features (h_final) via attention pool,
+    fuses with the global backbone GAP, and predicts both:
+    - 8-class softmax (Neutral, Happy, Sad, Surprise, Fear, Disgust, Anger, Contempt)
+    - 2-dim continuous V/A in [-1, 1] (via tanh)
+    """
+
+    def __init__(self, mefl_ch: int = 512, bb_ch: int = 768, n_classes: int = N_EMOTION,
+                 dropout: float = 0.25):
+        super().__init__()
+        self.attn = nn.Linear(mefl_ch, 1)
+        self.bb_proj = nn.Linear(bb_ch, mefl_ch)
+        self.trunk = nn.Sequential(
+            nn.Linear(mefl_ch * 2, 512),
+            nn.GELU(),
+            nn.Dropout(dropout),
+        )
+        self.cls_head = nn.Linear(512, n_classes)
+        self.va_head = nn.Linear(512, 2)
+
+    def forward(self, h_final: torch.Tensor, X_bb: torch.Tensor) -> dict:
+        # h_final: [B, N_AU, mefl_ch];  X_bb: [B, bb_ch, H, W]
+        w = self.attn(h_final).softmax(dim=1)
+        au_pooled = (h_final * w).sum(dim=1)            # [B, mefl_ch]
+        bb_pooled = X_bb.mean(dim=(-2, -1))             # [B, bb_ch]
+        fused = torch.cat([au_pooled, self.bb_proj(bb_pooled)], dim=-1)
+        z = self.trunk(fused)
+        return {
+            "emotion_logits": self.cls_head(z),
+            "va": torch.tanh(self.va_head(z)),          # [B, 2]
+        }
+
+
+class GazeHead(nn.Module):
+    """Eye-region landmark-conditional gaze prediction.
+
+    Architecture:
+      1. Query backbone tokens with eye-region landmark positions (left + right)
+         via multi-head cross-attention. Two separate query sets per eye.
+      2. Optional 2-node graph (left ↔ right eye) with 1 GatedGCN layer for
+         binocular reasoning.
+      3. Gate using AU-related features from h_final (AU05/07/09/43/45).
+      4. MLP → (yaw, pitch).
+    """
+
+    def __init__(self, bb_ch: int = 768, mefl_ch: int = 512, ch: int = 256,
+                 use_dual_eye_gcn: bool = True):
+        super().__init__()
+        self.use_dual_eye_gcn = use_dual_eye_gcn
+
+        self.lmk_proj = nn.Linear(2, bb_ch)
+        self.attn = nn.MultiheadAttention(bb_ch, num_heads=4, batch_first=True)
+        self.feat_proj = nn.Linear(bb_ch, ch)
+        if use_dual_eye_gcn:
+            self.dual_gcn = GatedGCNLayer(ch)
+
+        n_gate = len(GAZE_GATE_AU_IDX)
+        self.gate_proj = nn.Linear(mefl_ch * n_gate, ch)
+
+        in_dim = ch * 2 + ch    # left + right + au_gate
+        self.mlp = nn.Sequential(
+            nn.Linear(in_dim, 512), nn.GELU(),
+            nn.Linear(512, 2),
+        )
+
+    def forward(self, X_bb: torch.Tensor, mesh_pred: torch.Tensor,
+                h_final: torch.Tensor) -> torch.Tensor:
+        # X_bb: [B, bb_ch, H, W];  mesh_pred: [B, 478, 3];  h_final: [B, N_AU, mefl_ch]
+        B, C, H, W = X_bb.shape
+        kv = X_bb.flatten(2).transpose(1, 2)            # [B, H*W, bb_ch]
+
+        # Per-eye queries from predicted landmarks
+        left_q = self.lmk_proj(mesh_pred[:, MP_LEFT_EYE_IDX, :2])
+        right_q = self.lmk_proj(mesh_pred[:, MP_RIGHT_EYE_IDX, :2])
+
+        left_attn, _ = self.attn(left_q, kv, kv)
+        right_attn, _ = self.attn(right_q, kv, kv)
+        left_feat = self.feat_proj(left_attn.mean(dim=1))   # [B, ch]
+        right_feat = self.feat_proj(right_attn.mean(dim=1))
+
+        if self.use_dual_eye_gcn:
+            nodes = torch.stack([left_feat, right_feat], dim=1)  # [B, 2, ch]
+            edges = torch.zeros(B, 2, 2, left_feat.shape[-1], device=X_bb.device)
+            nodes, _ = self.dual_gcn(nodes, edges)
+            left_feat, right_feat = nodes[:, 0], nodes[:, 1]
+
+        # AU gating: eye-related AUs from MEFL h_final
+        au_gate_feats = h_final[:, GAZE_GATE_AU_IDX, :]      # [B, 5, mefl_ch]
+        au_gate = self.gate_proj(au_gate_feats.flatten(1))   # [B, ch]
+
+        combined = torch.cat([left_feat, right_feat, au_gate], dim=-1)
+        return self.mlp(combined)                            # [B, 2]
+
+
+# ============================ v2.1 heads ============================
+
+class EmotionVAHeadV2(nn.Module):
+    """v2.1: Two parallel paths into the emotion+V/A trunk.
+
+    Path A — AU-derived (from MEFL h_final):  attention pool → mefl_ch
+    Path B — Backbone GAP (from raw backbone): 2-layer MLP → mefl_ch
+                                                (was 1-layer Linear in v1)
+    fused = concat([A, B]) → trunk → cls_head + va_head
+
+    Rationale:
+      v1 head had backbone GAP shoved through one Linear(768→512) and
+      concatenated with the AU pool. The AU-derived path dominated because
+      it already carries refined per-AU semantic features.
+      v2.1 strengthens path B with a real MLP (Linear→GELU→Dropout→Linear)
+      so emotion/V/A can leverage spatial backbone features beyond what
+      gets distilled through the AU graph.
+
+    Identical output structure to v1 (emotion_logits + va) — drop-in.
+    """
+
+    def __init__(self, mefl_ch: int = 512, bb_ch: int = 768,
+                 n_classes: int = N_EMOTION, dropout: float = 0.25):
+        super().__init__()
+        self.attn = nn.Linear(mefl_ch, 1)
+        # Path B: deeper backbone-GAP encoder
+        self.bb_trunk = nn.Sequential(
+            nn.Linear(bb_ch, mefl_ch * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(mefl_ch * 2, mefl_ch),
+        )
+        # Fusion trunk (input: AU-pool ⊕ backbone-MLP = 2 × mefl_ch)
+        self.trunk = nn.Sequential(
+            nn.Linear(mefl_ch * 2, 512),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(512, 512),
+            nn.GELU(),
+            nn.Dropout(dropout),
+        )
+        self.cls_head = nn.Linear(512, n_classes)
+        self.va_head = nn.Linear(512, 2)
+
+    def forward(self, h_final: torch.Tensor, X_bb: torch.Tensor) -> dict:
+        # Path A: attention pool over the 24 AU node features
+        w = self.attn(h_final).softmax(dim=1)
+        au_pooled = (h_final * w).sum(dim=1)                  # [B, mefl_ch]
+        # Path B: backbone GAP through 2-layer MLP
+        bb_pooled = X_bb.mean(dim=(-2, -1))                   # [B, bb_ch]
+        bb_feat = self.bb_trunk(bb_pooled)                    # [B, mefl_ch]
+        fused = torch.cat([au_pooled, bb_feat], dim=-1)
+        z = self.trunk(fused)
+        return {
+            "emotion_logits": self.cls_head(z),
+            "va": torch.tanh(self.va_head(z)),
+        }
+
+
+class GazeHeadV2(nn.Module):
+    """v2.1: Backbone-GAP + landmark cross-attention, NO AU gating,
+    separate yaw and pitch regression heads (L2CS-Net pattern).
+
+    Rationale:
+      v1 GazeHead gated gaze prediction with eye-related AU features
+      (AU05, AU07, AU09, AU43, AU45) via gate_proj on h_final. But AU05
+      and AU43 are still at 0.0 F1 even after stage 3 — they're broken
+      signals, so the gating injected noise.
+
+      SOTA gaze models (L2CS-Net, GazeTR, GazeSymCAT) skip AU coupling
+      entirely. L2CS-Net specifically uses separate yaw and pitch FC
+      layers with their own losses — empirically more accurate than
+      a single 2-output regression.
+
+    Architecture:
+      X_bb GAP                 ─┐
+                                ├─ fuse via concat → trunk
+      eye_cross_attn (optional) ┘                       │
+                                                        ├─→ yaw_head (B, 1)
+                                                        └─→ pitch_head (B, 1)
+
+    The eye-cross-attention is kept as an optional residual signal (toggle
+    via `use_eye_cross_attn`). When True, queries from predicted mesh
+    eye-region landmarks attend over backbone tokens — same as v1 but
+    no GCN over the two eyes (was minor) and no AU gating.
+    """
+
+    def __init__(self, bb_ch: int = 768, mefl_ch: int = 512, ch: int = 256,
+                 use_eye_cross_attn: bool = True):
+        super().__init__()
+        self.use_eye_cross_attn = use_eye_cross_attn
+
+        # Backbone GAP path (primary)
+        self.bb_trunk = nn.Sequential(
+            nn.Linear(bb_ch, ch * 2),
+            nn.GELU(),
+            nn.Linear(ch * 2, ch),
+            nn.GELU(),
+        )
+
+        # Optional eye-region cross-attention path
+        if use_eye_cross_attn:
+            self.lmk_proj = nn.Linear(2, bb_ch)
+            self.attn = nn.MultiheadAttention(bb_ch, num_heads=4, batch_first=True)
+            self.eye_feat_proj = nn.Linear(bb_ch, ch)
+            fused_dim = ch + ch * 2   # backbone + left eye + right eye
+        else:
+            fused_dim = ch
+
+        self.trunk = nn.Sequential(
+            nn.Linear(fused_dim, 512),
+            nn.GELU(),
+            nn.Linear(512, 256),
+            nn.GELU(),
+        )
+        # Separate yaw & pitch heads (L2CS-Net pattern)
+        self.yaw_head = nn.Linear(256, 1)
+        self.pitch_head = nn.Linear(256, 1)
+
+    def forward(self, X_bb: torch.Tensor, mesh_pred: torch.Tensor) -> torch.Tensor:
+        # X_bb: [B, bb_ch, H, W];  mesh_pred: [B, 478, 3]
+        B, C, H, W = X_bb.shape
+
+        # Backbone GAP primary feature
+        bb_pooled = X_bb.mean(dim=(-2, -1))           # [B, bb_ch]
+        bb_feat = self.bb_trunk(bb_pooled)            # [B, ch]
+        parts = [bb_feat]
+
+        if self.use_eye_cross_attn:
+            kv = X_bb.flatten(2).transpose(1, 2)      # [B, H*W, bb_ch]
+            left_q = self.lmk_proj(mesh_pred[:, MP_LEFT_EYE_IDX, :2])
+            right_q = self.lmk_proj(mesh_pred[:, MP_RIGHT_EYE_IDX, :2])
+            left_attn, _ = self.attn(left_q, kv, kv)
+            right_attn, _ = self.attn(right_q, kv, kv)
+            left_feat = self.eye_feat_proj(left_attn.mean(dim=1))
+            right_feat = self.eye_feat_proj(right_attn.mean(dim=1))
+            parts.extend([left_feat, right_feat])
+
+        fused = torch.cat(parts, dim=-1)
+        z = self.trunk(fused)
+        yaw = self.yaw_head(z)                         # [B, 1]
+        pitch = self.pitch_head(z)                     # [B, 1]
+        return torch.cat([yaw, pitch], dim=-1)         # [B, 2]
+
+
+# ============================ Top-level ============================
+
+class MEGraphAUv2(nn.Module):
+    def __init__(self, cfg: ModelV2Config):
+        super().__init__()
+        self.cfg = cfg
+
+        self.backbone = timm.create_model(
+            cfg.backbone,
+            pretrained=cfg.pretrained,
+            features_only=True,
+            out_indices=[-1],
+            drop_path_rate=cfg.drop_path_rate,
+        )
+        in_ch = self.backbone.feature_info.channels()[-1]
+        self.proj = (
+            nn.Conv2d(in_ch, cfg.afg_channels, 1, bias=False)
+            if in_ch != cfg.afg_channels
+            else nn.Identity()
+        )
+        self.afg = AFG(cfg.afg_channels, cfg.afg_channels, cfg.n_au)
+        self.fgg = FGG(cfg.afg_channels, k=cfg.knn_k)
+        self.mefl = MEFL(cfg.mefl_channels, cfg.n_au, cfg.gcn_layers,
+                         use_layer_scale=cfg.mefl_use_layer_scale)
+        self.sc = SCHead(cfg.n_au, cfg.mefl_channels)
+        # Cooccurrence head: only present in v2 / v2.1 / v2.2 (use_head_v3=False).
+        # v2.3 drops it entirely — BP4D-skewed priors hurt DISFA+ transfer.
+        if not cfg.use_head_v3:
+            self.cooccur = CooccurrenceHead(cfg.mefl_channels)
+        self.lmk = LandmarkHead(cfg.afg_channels)
+        self.pose = PoseHead(cfg.afg_channels)
+
+        # Head dispatch — v3 (v2.3) > v2 (v2.1) > v1 default
+        if cfg.use_head_v3:
+            from feat.multitask.heads_v3 import (
+                UnifiedFeatures, GazeHeadV3, EmotionVAHeadV3,
+            )
+            self.unified = UnifiedFeatures(bb_ch=in_ch, lmk_dim=cfg.unified_lmk_dim,
+                                            image_size=cfg.image_size)
+            self.emotion = EmotionVAHeadV3(
+                in_dim=self.unified.out_dim,
+                n_classes=cfg.n_emotion,
+                dropout=cfg.emotion_head_dropout,
+            )
+            self.gaze = GazeHeadV3(in_dim=self.unified.out_dim)
+        elif cfg.use_head_v2:
+            self.emotion = EmotionVAHeadV2(
+                mefl_ch=cfg.mefl_channels, bb_ch=in_ch,
+                n_classes=cfg.n_emotion, dropout=cfg.emotion_head_dropout,
+            )
+            self.gaze = GazeHeadV2(
+                bb_ch=in_ch, mefl_ch=cfg.mefl_channels,
+                use_eye_cross_attn=cfg.use_dual_eye_gcn,
+            )
+        else:
+            self.emotion = EmotionVAHead(
+                mefl_ch=cfg.mefl_channels, bb_ch=in_ch,
+                n_classes=cfg.n_emotion, dropout=cfg.emotion_head_dropout,
+            )
+            self.gaze = GazeHead(
+                bb_ch=in_ch, mefl_ch=cfg.mefl_channels,
+                use_dual_eye_gcn=cfg.use_dual_eye_gcn,
+            )
+
+        # Homoscedastic σ (Kendall) — one per task
+        self.log_var_au = nn.Parameter(torch.zeros(cfg.n_au))
+        self.log_var_mesh = nn.Parameter(torch.zeros(()))
+        self.log_var_pose = nn.Parameter(torch.zeros(()))
+        # log_var_cooccur only when cooccur loss is active
+        if not cfg.use_head_v3:
+            self.log_var_cooccur = nn.Parameter(torch.zeros(()))
+        self.log_var_emotion = nn.Parameter(torch.zeros(()))
+        self.log_var_va = nn.Parameter(torch.zeros(()))
+        self.log_var_gaze = nn.Parameter(torch.zeros(()))
+
+    def forward(self, x: torch.Tensor) -> dict:
+        feats = self.backbone(x)[-1]                # [B, bb_ch, H, W]
+        X = self.proj(feats)                         # [B, afg_ch, H, W]
+        U, v = self.afg(X)                           # [B, N, C, H, W], [B, N, C]
+        v_fgg = self.fgg(v)                          # [B, N, C]
+        h, e = self.mefl(U, X, v_fgg)                # [B, N, C], [B, N, N, C]
+
+        p_au = self.sc(h)                            # [B, N]
+        mesh = self.lmk(X)                           # [B, 478, 3]
+        pose = self.pose(X)                          # [B, 6]
+
+        # Head dispatch
+        if self.cfg.use_head_v3:
+            # v2.3: unified features = backbone GAP ∥ proj(mesh_xy)
+            unified = self.unified(feats, mesh)      # [B, bb_ch + lmk_dim]
+            emotion_out = self.emotion(unified)
+            gaze = self.gaze(unified)
+            cooc_logits = None
+        else:
+            # v2 / v2.1: heads use h (AU node features) + raw backbone feats
+            cooc_logits = self.cooccur(e)            # [B, N, N, 4]
+            emotion_out = self.emotion(h, feats)
+            if isinstance(self.gaze, GazeHeadV2):
+                gaze = self.gaze(feats, mesh)
+            else:
+                gaze = self.gaze(feats, mesh, h)
+
+        return {
+            "p_au": p_au,
+            "mesh": mesh,
+            "pose": pose,
+            "cooccur": cooc_logits,
+            "emotion_logits": emotion_out["emotion_logits"],
+            "va": emotion_out["va"],
+            "gaze": gaze,
+            "h": h,
+            "e": e,
+        }
+
+    # ------------- per-stage freeze utilities -------------
+
+    def freeze_backbone(self, freeze: bool = True):
+        for p in self.backbone.parameters():
+            p.requires_grad_(not freeze)
+        for p in self.proj.parameters():
+            p.requires_grad_(not freeze)
+
+    def freeze_anfl(self, freeze: bool = True):
+        for m in (self.afg, self.fgg, self.sc):
+            for p in m.parameters():
+                p.requires_grad_(not freeze)
+
+    def freeze_mefl(self, freeze: bool = True):
+        for m in (self.mefl, self.cooccur):
+            for p in m.parameters():
+                p.requires_grad_(not freeze)

--- a/feat/tests/test_detector_v2.py
+++ b/feat/tests/test_detector_v2.py
@@ -47,7 +47,9 @@ def test_single_face_schema(detector, single_face_img):
 def test_single_face_values(detector, single_face_img):
     fex = detector.detect(single_face_img, progress_bar=False)
     emo = fex[EMOTION_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
-    assert np.isclose(emo.sum(), 1.0, atol=1e-4)
+    # Softmax runs under bf16 autocast by default, so the sum is 1.0 only to
+    # bf16 precision (~1e-2), not fp32.
+    assert np.isclose(emo.sum(), 1.0, atol=2e-2)
     aus = fex[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
     assert aus.min() >= 0.0 and aus.max() <= 1.0
     assert -1.0 <= float(fex["valence"].iloc[0]) <= 1.0

--- a/feat/tests/test_detector_v2.py
+++ b/feat/tests/test_detector_v2.py
@@ -57,17 +57,37 @@ def test_single_face_values(detector, single_face_img):
 
 def test_landmarks_inside_facebox(detector, single_face_img):
     """The dlib-68 block (derived from the 478 mesh) must land within the
-    detected facebox — guards the mesh->original-frame coordinate inversion."""
+    detected facebox — guards the mesh->original-frame coordinate transform.
+
+    Tolerance is tight (strictly inside, +/-5% margin): a looser bound hid a
+    real axis-major/interleaved scramble bug that put landmarks ~48px off on
+    non-square crops while still landing inside a 1.3x-padded box.
+    """
     fex = detector.detect(single_face_img, progress_bar=False)
     xs = fex[[f"x_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
     ys = fex[[f"y_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
     x0 = float(fex["FaceRectX"].iloc[0]); y0 = float(fex["FaceRectY"].iloc[0])
     w = float(fex["FaceRectWidth"].iloc[0]); h = float(fex["FaceRectHeight"].iloc[0])
     inside = (
-        (xs >= x0 - 0.3 * w) & (xs <= x0 + 1.3 * w)
-        & (ys >= y0 - 0.3 * h) & (ys <= y0 + 1.3 * h)
+        (xs >= x0 - 0.05 * w) & (xs <= x0 + 1.05 * w)
+        & (ys >= y0 - 0.05 * h) & (ys <= y0 + 1.05 * h)
     )
-    assert inside.mean() > 0.95
+    assert inside.mean() > 0.9
+
+
+def test_no_face_returns_nan_predictions(detector):
+    """A face-less image yields one row with NaN facebox AND NaN predictions
+    (AU/emotion/identity/landmarks) — not fabricated values from the zeroed
+    placeholder crop."""
+    import os
+    from feat.utils.io import get_test_data_path
+    no_face = os.path.join(get_test_data_path(), "free-mountain-vector-01.jpg")
+    fex = detector.detect(no_face, progress_bar=False)
+    assert fex["FaceRectX"].isna().all()
+    assert fex[AU_COLUMNS_V2].isna().all().all()
+    assert fex[EMOTION_COLUMNS_V2].isna().all().all()
+    assert fex["Identity_1"].isna().all()
+    assert fex["x_0"].isna().all()
 
 
 def test_multi_face(detector, multi_face_img):

--- a/feat/tests/test_detector_v2.py
+++ b/feat/tests/test_detector_v2.py
@@ -68,8 +68,10 @@ def test_landmarks_inside_facebox(detector, single_face_img):
     fex = detector.detect(single_face_img, progress_bar=False)
     xs = fex[[f"x_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
     ys = fex[[f"y_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
-    x0 = float(fex["FaceRectX"].iloc[0]); y0 = float(fex["FaceRectY"].iloc[0])
-    w = float(fex["FaceRectWidth"].iloc[0]); h = float(fex["FaceRectHeight"].iloc[0])
+    x0 = float(fex["FaceRectX"].iloc[0])
+    y0 = float(fex["FaceRectY"].iloc[0])
+    w = float(fex["FaceRectWidth"].iloc[0])
+    h = float(fex["FaceRectHeight"].iloc[0])
     inside = (
         (xs >= x0 - 0.05 * w) & (xs <= x0 + 1.05 * w)
         & (ys >= y0 - 0.05 * h) & (ys <= y0 + 1.05 * h)

--- a/feat/tests/test_detector_v2.py
+++ b/feat/tests/test_detector_v2.py
@@ -1,0 +1,86 @@
+"""Tests for Detectorv2 (RetinaFace + v2.3 multitask model + ArcFace).
+
+These hit the network on first run (downloads py-feat/face_multitask_v1 +
+arcface_r50 + the timm backbone). Kept lightweight: one single-face and one
+multi-face image, plus schema + value-range + batch-consistency checks.
+"""
+import numpy as np
+import pytest
+import torch
+
+from feat import Detectorv2
+from feat.data import Fex
+from feat.multitask import (
+    AU_COLUMNS_V2,
+    EMOTION_COLUMNS_V2,
+    VA_COLUMNS_V2,
+    MESH_COLUMNS_V2,
+)
+
+_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@pytest.fixture(scope="module")
+def detector():
+    return Detectorv2(device=_DEVICE)
+
+
+def test_init(detector):
+    assert detector.info["face_model"] == "retinaface"
+    assert detector.info["identity_model"] == "arcface"
+    assert detector.multitask is not None
+
+
+def test_single_face_schema(detector, single_face_img):
+    fex = detector.detect(single_face_img, progress_bar=False)
+    assert isinstance(fex, Fex)
+    assert len(fex) == 1
+    assert fex.columns.duplicated().sum() == 0
+    for col in AU_COLUMNS_V2 + EMOTION_COLUMNS_V2 + VA_COLUMNS_V2:
+        assert col in fex.columns
+    assert all(c in fex.columns for c in ["gaze_pitch", "gaze_yaw", "gaze_angle"])
+    assert all(c in fex.columns for c in ["Pitch", "Roll", "Yaw", "X", "Y", "Z"])
+    assert sum(c.startswith("Identity_") for c in fex.columns) == 512
+    assert sum(c in MESH_COLUMNS_V2 for c in fex.columns) == len(MESH_COLUMNS_V2)
+
+
+def test_single_face_values(detector, single_face_img):
+    fex = detector.detect(single_face_img, progress_bar=False)
+    emo = fex[EMOTION_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    assert np.isclose(emo.sum(), 1.0, atol=1e-4)
+    aus = fex[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    assert aus.min() >= 0.0 and aus.max() <= 1.0
+    assert -1.0 <= float(fex["valence"].iloc[0]) <= 1.0
+    assert -1.0 <= float(fex["arousal"].iloc[0]) <= 1.0
+    assert fex["Identity_1"].notna().iloc[0]
+
+
+def test_landmarks_inside_facebox(detector, single_face_img):
+    """The dlib-68 block (derived from the 478 mesh) must land within the
+    detected facebox — guards the mesh->original-frame coordinate inversion."""
+    fex = detector.detect(single_face_img, progress_bar=False)
+    xs = fex[[f"x_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
+    ys = fex[[f"y_{i}" for i in range(68)]].iloc[0].to_numpy(dtype=float)
+    x0 = float(fex["FaceRectX"].iloc[0]); y0 = float(fex["FaceRectY"].iloc[0])
+    w = float(fex["FaceRectWidth"].iloc[0]); h = float(fex["FaceRectHeight"].iloc[0])
+    inside = (
+        (xs >= x0 - 0.3 * w) & (xs <= x0 + 1.3 * w)
+        & (ys >= y0 - 0.3 * h) & (ys <= y0 + 1.3 * h)
+    )
+    assert inside.mean() > 0.95
+
+
+def test_multi_face(detector, multi_face_img):
+    fex = detector.detect(multi_face_img, progress_bar=False)
+    assert len(fex) == 5
+    assert fex["Identity_1"].notna().all()
+
+
+def test_batch_size_consistency(detector, single_face_img):
+    """Same image twice in one batch should give identical predictions."""
+    fex = detector.detect([single_face_img, single_face_img],
+                          batch_size=2, output_size=512, progress_bar=False)
+    assert len(fex) == 2
+    a = fex[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    b = fex[AU_COLUMNS_V2].iloc[1].to_numpy(dtype=float)
+    np.testing.assert_allclose(a, b, atol=1e-4)

--- a/feat/tests/test_detector_v2.py
+++ b/feat/tests/test_detector_v2.py
@@ -106,3 +106,39 @@ def test_batch_size_consistency(detector, single_face_img):
     a = fex[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
     b = fex[AU_COLUMNS_V2].iloc[1].to_numpy(dtype=float)
     np.testing.assert_allclose(a, b, atol=1e-4)
+
+
+def test_arcface_weights_loaded_not_random():
+    """Guard the trained-weights load: a bare ``ArcFace(backbone='r50')`` (the
+    bug this fixes) ships *random* init, so every construction would embed the
+    same face differently. Loaded weights are deterministic — two independent
+    loads must agree — and carry real signal (embeddings aren't ~0)."""
+    from feat.identity_detectors.arcface.arcface_model import (
+        load_arcface_identity_detector,
+    )
+    torch.manual_seed(0)
+    x = torch.rand(2, 3, 112, 112)
+    a = load_arcface_identity_detector("cpu")
+    b = load_arcface_identity_detector("cpu")
+    with torch.no_grad():
+        ea = a(x).numpy()
+        eb = b(x).numpy()
+    np.testing.assert_allclose(ea, eb, atol=1e-5)
+    assert np.abs(ea).mean() > 1e-3
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="bf16 autocast default is CUDA-only")
+def test_bf16_matches_fp32(single_face_img):
+    """bf16 autocast is the default on CUDA, but the CPU test run never
+    exercises it. Pin the bf16-vs-fp32 agreement (AU within model noise, emotion
+    still a valid simplex) so a real bf16 regression can't pass silently."""
+    fex16 = Detectorv2(device="cuda", amp=True).detect(
+        single_face_img, progress_bar=False)
+    fex32 = Detectorv2(device="cuda", amp=False).detect(
+        single_face_img, progress_bar=False)
+    au16 = fex16[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    au32 = fex32[AU_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    np.testing.assert_allclose(au16, au32, atol=0.05)
+    emo16 = fex16[EMOTION_COLUMNS_V2].iloc[0].to_numpy(dtype=float)
+    assert np.isclose(emo16.sum(), 1.0, atol=2e-2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ h5py>=2.7.0
 Pillow>=6.0.0
 torch>=2.5
 torchvision>=0.20
+timm>=1.0.11
 scikit-image>=0.19
 joblib
 easing_functions

--- a/scripts/bench_detectors.py
+++ b/scripts/bench_detectors.py
@@ -162,10 +162,19 @@ def _build_mp_detector(device):
     )
 
 
+def _build_detectorv2(device):
+    from feat.detector_v2 import Detectorv2
+    # Single multitask model (RetinaFace -> ConvNeXt-V2 multitask head) +
+    # arcface identity. AU/emotion/gaze/landmark/pose all come from one
+    # forward pass, so this is a different cost profile from the v1 stack.
+    return Detectorv2(device=device, identity_model="arcface")
+
+
 CONFIGS = [
     ("img2pose", _build_d_img2pose),
     ("retinaface", _build_d_retinaface),
     ("MPDetector retinaface", _build_mp_detector),
+    ("Detectorv2 multitask", _build_detectorv2),
 ]
 
 
@@ -523,6 +532,16 @@ def _parse_args() -> argparse.Namespace:
         help="Skip the image-batch sweep.",
     )
     p.add_argument(
+        "--configs",
+        nargs="+",
+        default=None,
+        help=(
+            "Substring filter on config labels to run a subset, e.g. "
+            "`--configs Detectorv2` or `--configs retinaface Detectorv2`. "
+            "Default: all configs."
+        ),
+    )
+    p.add_argument(
         "--markdown",
         nargs="?",
         const="__default__",
@@ -582,6 +601,17 @@ def _gpu_summary() -> str:
 
 def main() -> None:
     args = _parse_args()
+
+    # Optionally restrict which detector configs run (substring match on label).
+    if args.configs is not None:
+        global CONFIGS
+        selected = [c for c in CONFIGS
+                    if any(s.lower() in c[0].lower() for s in args.configs)]
+        if not selected:
+            raise SystemExit(
+                f"--configs {args.configs} matched no configs; available: "
+                f"{[c[0] for c in CONFIGS]}")
+        CONFIGS = selected
 
     all_devices = _resolve_devices(args.devices)
 


### PR DESCRIPTION
## Summary

Adds **Detectorv2**, a new py-feat detector that runs the v2.3 multitask model in a single forward pass: RetinaFace detection → ConvNeXt-V2 multitask model (24 AUs, 8 emotions, valence/arousal, gaze, 478-point face mesh, 6D head pose) → ArcFace identity → native-v2 `Fex`. v1 `Detector` is kept as-is (`Detectorv1` alias); this is purely additive.

The landmark block is the dlib-68 subset derived from the 478 mesh, so existing `Fex` helpers expecting 68 points keep working; the full mesh is available in `mesh_*` columns.

## What's here

- `feat/multitask/` — vendored v2.3 model (`model_v2.py`, `heads_v3.py`) + `MultitaskModel` inference wrapper + v2 `Fex` column constants.
- `feat/detector_v2.py` — `Detectorv2` (detect_faces / forward / detect), mesh→original-frame coordinate transform, NaN-masking for no-detection rows.
- HF model `py-feat/face_multitask_v1` (weights + model card).
- bf16 autocast inference (default on CUDA, ~3x model forward; `amp=False` forces fp32), optional `compile=` flag, GPU-side uint8→float cast in `detect_faces`.
- Tests (9) + a Detectorv2 config in `scripts/bench_detectors.py` + Blackwell throughput reports.

## Performance (Blackwell RTX PRO 6000, batch 16)

Fastest full-pipeline detector on every fixture: long video 215 fps (4.6 ms/frame) vs retinaface-v1 161, MPDetector 194, img2pose 31 — while producing AU+emotion+V/A+gaze+mesh+pose+identity in one model.

## Code review (this branch)

`code-review` on `fcabbf0..HEAD` (the perf commits) plus a full-branch identity audit found and fixed one **blocker**: Detectorv2 constructed `ArcFace(backbone="r50")` but never loaded the trained checkpoint → random-init identity embeddings (silent, no crash). Fixed by extracting `load_arcface_identity_detector()` as the single load path and calling it from v2; added a regression test that two independent loads must agree and carry signal, plus a CUDA-gated bf16-vs-fp32 agreement test. Remaining minor findings (non_blocking inert without pin_memory, MPS amp footgun, device-resolution single-source-of-truth, dead imports, mesh GPU roundtrip) are noted for follow-up.

All 9 Detectorv2 tests pass.