### PR TITLE
feat(plotting): configurable cmap for muscle heatmaps

### DIFF
--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -350,13 +350,14 @@ def draw_vectorfield(
     return ax
 
 
-def draw_muscles(currx, curry, au=None, ax=None, *args, **kwargs):
+def draw_muscles(currx, curry, au=None, ax=None, cmap="Blues", *args, **kwargs):
     """Draw Muscles
 
     Args:
         currx: vector (len(68)) of x coordinates
         curry: vector (len(68)) of y coordinates
         ax: matplotlib axis to add
+        cmap: seaborn/matplotlib colormap name (or palette) for heatmap muscles
     """
     masseter_l = plt.Polygon(
         [
@@ -776,7 +777,7 @@ def draw_muscles(currx, curry, au=None, ax=None, *args, **kwargs):
                 del kwargs[muscle]
     for muscle in todraw.keys():
         if todraw[muscle] == "heatmap":
-            muscles[muscle].set_color(get_heat(muscle, au, facet))
+            muscles[muscle].set_color(get_heat(muscle, au, facet, cmap))
         else:
             muscles[muscle].set_color(todraw[muscle])
         ax.add_patch(muscles[muscle], *args, **kwargs)
@@ -825,19 +826,19 @@ def draw_muscles(currx, curry, au=None, ax=None, *args, **kwargs):
     return ax
 
 
-def get_heat(muscle, au, log):
+def get_heat(muscle, au, log, cmap="Blues"):
     """Function to create heatmap from au vector
 
     Args:
         muscle (string): string representation of a muscle
         au (list): vector of action units
         log (boolean): whether the action unit values are on a log scale
-
+        cmap: seaborn/matplotlib colormap name (or palette) for the heatmap
 
     Returns:
         color of muscle according to its au value
     """
-    q = sns.color_palette("Blues", 151)
+    q = sns.color_palette(cmap, 151)
     unit = 0
     aus = {
         "masseter_l": 15,
@@ -947,6 +948,7 @@ def plot_face(
     gaze=None,
     muscle_scaler=None,
     symmetrize=True,
+    cmap="Blues",
     *args,
     **kwargs,
 ):
@@ -964,6 +966,7 @@ def plot_face(
         linewidth: matplotlib linewidth
         linestyle: matplotlib linestyle
         gaze: array of gaze vectors (len(4))
+        cmap: seaborn/matplotlib colormap name (or palette) for muscle heatmaps; default "Blues"
 
     Returns:
         ax: plot handle
@@ -1010,7 +1013,7 @@ def plot_face(
             au = minmax_scale(au, feature_range=(0, 100 * muscle_scaler))
         else:
             au = muscle_scaler.transform(np.array(au).reshape(-1, 1)).squeeze()
-        ax = draw_muscles(currx, curry, ax=ax, au=au, **muscles)
+        ax = draw_muscles(currx, curry, ax=ax, au=au, cmap=cmap, **muscles)
 
     if gaze is not None and len((gaze)) != 4:
         warnings.warn(

--- a/feat/tests/test_plot.py
+++ b/feat/tests/test_plot.py
@@ -8,6 +8,7 @@ from feat.plotting import (
     draw_vectorfield,
     predict,
     animate_face,
+    get_heat,
 )
 import matplotlib
 import pytest
@@ -90,6 +91,21 @@ def test_plot_face(au, au2):
     with pytest.raises(ValueError):
         plot_face(model=au, au=au, vectorfield={"noreference": predict(au2)})
 
+    plt.close("all")
+
+
+def test_plot_face_cmap(au):
+    # cmap threads through plot_face -> draw_muscles -> get_heat. Default is
+    # "Blues"; a custom cmap must change the heatmap colors and still render.
+    import numpy as np
+
+    active = np.full(20, 50.0)
+    default = get_heat("zyg_maj_l", active, False)
+    assert get_heat("zyg_maj_l", active, False, "Blues") == default
+    assert get_heat("zyg_maj_l", active, False, "Reds") != default
+
+    plot_face(au=au, muscles={"all": "heatmap"}, cmap="Reds")
+    assert_plot_face_visible(plt.gca())
     plt.close("all")
 
 


### PR DESCRIPTION
Adds a `cmap` argument to `plot_face` / `draw_muscles` / `get_heat` so the muscle-activation heatmap palette is configurable. Default stays `"Blues"`, so existing output is unchanged.

Reimplements the idea from #237 (@Ben-FCC), which targeted the frozen v0.6 `main` and passed `cmap` positionally into `draw_muscles`' `au` slot (raising `TypeError`). Here it's threaded by keyword end-to-end, with a regression test (`test_plot_face_cmap`) asserting the default is unchanged, a custom cmap changes the colors, and `plot_face(cmap=...)` still renders.

Closes #237.