### PR TITLE
chore: dead-code cleanup + HF model-verification audit

### DIFF
--- a/feat/utils/__init__.py
+++ b/feat/utils/__init__.py
@@ -397,13 +397,6 @@ def set_torch_device(device="cpu"):
         return device
 
 
-# TODO: Refactor the output of each detector into a reliable dataclass with the same
-# structure to avoid utility functions like this
-def is_list_of_lists_empty(list_of_lists):
-    """Helper function to check if list of lists is empty"""
-    return not any(list_of_lists)
-
-
 def flatten_list(data):
     """Helper function to flatten a list of lists"""
     flat_list = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ numexpr>=2.8.5
 numpy>=1.24
 scipy>=1.11
 scikit-learn>=1.3
-pywavelets>=0.3.0
 h5py>=2.7.0
 Pillow>=6.0.0
 torch>=2.5

--- a/scripts/verify_hf_models.py
+++ b/scripts/verify_hf_models.py
@@ -1,0 +1,95 @@
+"""Verify every Hugging Face model artifact py-feat lazily downloads is live.
+
+The detectors / plotting / eval paths pull weights from repos under the
+``py-feat/`` org via ``hf_hub_download`` at first use. If a repo (or an
+expected file in it) isn't published, users hit a 404 only when they first
+exercise that code path — never at install time. This script resolves every
+referenced repo up front (metadata only, no weight download) so a missing
+artifact is caught before release.
+
+The repo list is derived from grepping ``hf_hub_download(repo_id=...)`` /
+``HF_REPO`` across ``feat/``. Keep it in sync if new models are wired in.
+
+Usage:
+    python scripts/verify_hf_models.py            # all repos
+    python scripts/verify_hf_models.py --files    # also list each repo's files
+
+Exits non-zero if any repo fails to resolve.
+"""
+
+import argparse
+import sys
+
+from huggingface_hub import HfApi
+from huggingface_hub.utils import RepositoryNotFoundError, GatedRepoError
+
+# (repo_id, [expected files] or None). Files checked only when given.
+MODEL_REPOS = [
+    ("py-feat/xgb_au", None),
+    ("py-feat/svm_au", None),
+    ("py-feat/svm_emo", None),
+    ("py-feat/img2pose", None),
+    ("py-feat/resmasknet", None),
+    ("py-feat/facenet", None),
+    ("py-feat/mobilefacenet", None),
+    ("py-feat/mobilenet", None),
+    ("py-feat/pfld", None),
+    ("py-feat/l2cs", None),
+    ("py-feat/pose_mlp_v2", None),
+    ("py-feat/pose_mlp_v1", None),  # legacy fallback
+    ("py-feat/mp_blendshapes", None),
+    ("py-feat/bs_to_au", None),
+    ("py-feat/au_to_landmarks", None),
+    ("py-feat/au_to_mesh", None),
+    ("py-feat/landmarks68_to_mesh478", None),
+    ("py-feat/retinaface_r34", None),
+    ("py-feat/arcface_r50", None),
+    ("py-feat/face_multitask_v2", None),  # Detectorv2
+    ("py-feat/face_multitask_v1", None),
+]
+
+# Intentionally excluded: py-feat/mp_facemesh_v2 (the MediaPipe mesh model is
+# mid-transition — legacy file slated for deletion — verify separately).
+EXCLUDED = ["py-feat/mp_facemesh_v2"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--files", action="store_true", help="list files per repo")
+    args = ap.parse_args()
+
+    api = HfApi()
+    failures = []
+    print(f"Verifying {len(MODEL_REPOS)} HF model repos (excluding {EXCLUDED})\n")
+    for repo_id, expected in MODEL_REPOS:
+        try:
+            info = api.repo_info(repo_id)
+            files = [s.rfilename for s in info.siblings]
+            missing = [f for f in (expected or []) if f not in files]
+            if missing:
+                failures.append((repo_id, f"missing files: {missing}"))
+                status = f"FAIL  missing {missing}"
+            else:
+                status = f"ok    ({len(files)} files)"
+            print(f"  {repo_id:<34} {status}")
+            if args.files:
+                for f in files:
+                    print(f"       - {f}")
+        except (RepositoryNotFoundError, GatedRepoError) as e:
+            failures.append((repo_id, type(e).__name__))
+            print(f"  {repo_id:<34} FAIL  {type(e).__name__}")
+        except Exception as e:  # network, auth, etc.
+            failures.append((repo_id, f"{type(e).__name__}: {e}"))
+            print(f"  {repo_id:<34} ERROR {type(e).__name__}")
+
+    print()
+    if failures:
+        print(f"{len(failures)} repo(s) failed to resolve:")
+        for repo_id, why in failures:
+            print(f"  - {repo_id}: {why}")
+        sys.exit(1)
+    print("All referenced HF model repos resolve.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Dead-code removal (verified zero-risk)
- Remove orphaned helper `feat.utils.is_list_of_lists_empty()` (0 references anywhere).
- Drop `pywavelets` from `requirements.txt` — never imported (`feat.utils.stats.wavelet` is a hand-coded Morlet impl).

**Deliberately *not* removed:**
- `numexpr` — pandas uses it as the default engine for the one `MPDetector.py` `df.query()` (optional accelerator, not dead).
- `iplot_detections(frame_duration=...)` — documented public param that's unused in the body. That's a **latent bug** (animation speed ignored), not dead code; should be *wired up*, not deleted. Flagging separately.
- The `plotting.py` legacy v1 viz-model `can_load_joblib` / py3.7-3.8 branches — dead on 3.11+ but inside a load-bearing legacy loader; left for a careful follow-up.

## HF model-verification audit (`scripts/verify_hf_models.py`)
Release-gate script that resolves every HF model repo py-feat lazily downloads (metadata only). **Result: 20/21 resolve**, including the previously-pending `face_multitask_v2` (Detectorv2) and `arcface_r50`. `pose_mlp_v1` is absent but unreachable (loader prefers `pose_mlp_v2`, swallows the v1 404). `mp_facemesh_v2` excluded per the mp-mesh-in-transition steer.