### PR TITLE
ci: Claude Code Action — @claude mention, issue triage, PR review

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,58 @@
+# Automatic first-pass triage when a new issue is opened: categorize, request a
+# reproduction when missing, flag likely duplicates, and suggest labels. Issue
+# text is not executable fork code, so this is safe to run automatically.
+#
+# Requires `issues: write` so Claude can apply labels / post a comment (via the
+# `gh` CLI authenticated by GITHUB_TOKEN). Steering lives in REVIEW.md + CLAUDE.md.
+#
+# NOTE: `issues`-triggered workflows run from the workflow file on the DEFAULT
+# branch — this file must be on `main` to fire.
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: claude-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    if: github.event.issue.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Triage GitHub issue #${{ github.event.issue.number }} in this repo.
+            Follow REVIEW.md (triage section) and CLAUDE.md.
+
+            Do the following, using the `gh` CLI for any label/comment writes:
+            1. Categorize: bug, feature-request, question, or documentation.
+            2. If it's a bug without clear reproduction steps, add the
+               `needs-repro` label and post ONE concise comment asking for a
+               minimal repro (version, OS, code snippet, expected vs actual).
+            3. Search existing OPEN and recently CLOSED issues; if it looks like
+               a duplicate, say which issue and add `possible-duplicate`.
+            4. Be aware many v0.6-era requests are already resolved in v0.7 —
+               check before treating something as new (see CLAUDE.md roadmap).
+            5. Apply at most 2-3 labels total. Only use labels that already
+               exist in the repo (list them with `gh label list` first; do not
+               create new labels).
+
+            Keep any comment short and friendly. Do not close the issue.
+          claude_args: |
+            --max-turns 6
+            --model claude-sonnet-4-6
+            --allowedTools read,bash

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 concurrency:
   group: claude-triage-${{ github.event.issue.number }}

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,56 @@
+# On-demand Claude Code assistant, triggered by an `@claude` mention in an
+# issue or PR comment. This is the backbone of the setup: it works for any
+# issue/PR (including PRs from forks, because comment events run in the base
+# repo with secrets), and it is gated to maintainers so fork authors can't
+# trigger runs against the maintainer's Max credits or reach the token.
+#
+# SETUP (one-time, done by a maintainer with a Claude Pro/Max subscription):
+#   1. Run `claude setup-token` locally to mint an OAuth token.
+#   2. Add it as the repo secret CLAUDE_CODE_OAUTH_TOKEN
+#      (Settings -> Secrets and variables -> Actions).
+#   3. Run `/install-github-app` (or install https://github.com/apps/claude).
+#
+# NOTE: issue_comment-triggered workflows always run from the workflow file on
+# the DEFAULT branch. This file must be on `main` to fire for comments.
+#
+# USAGE: comment `@claude <request>` on an issue or PR. Add the word `opus`
+# (e.g. `@claude opus, review the concurrency logic`) to use Opus for a harder
+# task; otherwise it runs on Sonnet.
+name: Claude (@claude mention)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    # Only maintainers (repo owner / org members / collaborators) can trigger,
+    # and only when the comment actually contains `@claude`.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Balanced posture: Sonnet by default; Opus on request via `opus` in
+          # the comment. Read-only tools — no commits/pushes from CI.
+          claude_args: |
+            --max-turns 14
+            --model ${{ contains(github.event.comment.body, 'opus') && 'claude-opus-4-8' || 'claude-sonnet-4-6' }}
+            --allowedTools read,bash

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -28,6 +28,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  id-token: write
 
 concurrency:
   group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: claude-pr-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,49 @@
+# Automatic PR review on open, for SAME-REPO branches only. Fork PRs are
+# intentionally skipped here (GitHub withholds secrets from fork-triggered
+# `pull_request` runs anyway, and running the credentialed action on untrusted
+# fork code is unsafe) — review those on demand by commenting `@claude review`
+# (see claude-mention.yml).
+#
+# `pull_request` workflows run from the PR's BASE branch, so this fires for PRs
+# targeting whatever branch carries this file (e.g. v0.7-dev).
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Same-repo PRs only; forks are handled on-demand via @claude.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Follow REVIEW.md and CLAUDE.md.
+            Focus on correctness/logic bugs, missing test coverage, breaking
+            API changes without deprecation, and consistency with existing
+            patterns. Respect the load-bearing gotchas in CLAUDE.md (do not
+            suggest removing OMP_NUM_THREADS, the skops/xgb fallbacks, etc.).
+            Be concise and actionable; lead with anything important, keep nits
+            few. This is advisory — do not approve or request-changes formally.
+          claude_args: |
+            --max-turns 12
+            --model claude-sonnet-4-6
+            --allowedTools read,bash

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,59 @@
+# Review & triage guidelines for Claude Code automation
+
+These instructions steer the Claude Code GitHub Action (PR review, issue
+triage, and `@claude` mentions). They complement `CLAUDE.md` — read that too;
+its conventions and load-bearing gotchas always apply.
+
+## PR review
+
+**Lead with what matters. Keep nits few.** A review that buries one real bug
+under ten style nits is worse than a short one. Order findings by severity and
+say plainly when the PR looks good.
+
+Flag as **Important**:
+- Correctness / logic bugs, especially in the multi-face / batched paths
+  (`(image|video) × (single|multi-face) × (batch=1|batch>1)` is the matrix
+  that has historically broken — see `feat/tests`).
+- Breaking public-API changes without a deprecation path.
+- New public function/keyword that's documented but unused in the body, or a
+  parameter that silently does nothing (this has happened — e.g. an animation
+  `frame_duration` that wasn't wired up). Either wire it or don't ship it.
+- Device-handoff bugs: tensors created on CPU while weights are on MPS/CUDA.
+- Missing test coverage for new behavior (the suite targets the device/shape
+  matrix; new code paths should be exercised).
+- `try/except` scaffolding that masks a symptom instead of fixing root cause.
+
+**Do NOT flag** (these are deliberate — see `CLAUDE.md`):
+- The `OMP_NUM_THREADS=1` block in `feat/__init__.py`.
+- The `_patch_xgboost_setstate_for_skops` shim.
+- The xgb/svm `*_v2.skops`→v1 and `mp_facemesh_v2` TorchScript→legacy fallbacks.
+- `num_workers=0` as the default.
+- Absence of AI attribution in commits — that's required, not an oversight.
+
+**Style:** match `CLAUDE.md` — comments only where the WHY is non-obvious; no
+multi-paragraph docstrings on internal methods. Don't ask for comment churn.
+
+The review is advisory. Do not formally approve or request-changes; a human
+maintainer runs the merge.
+
+## Issue triage
+
+- **Require a reproduction for bugs.** If steps are missing, add `needs-repro`
+  and ask once for: py-feat version, OS/Python, a minimal code snippet, and
+  expected vs. actual. Don't interrogate; one friendly ask.
+- **Check before treating as new.** Many v0.6-era requests are already handled
+  in v0.7 (HuggingFace model hosting, disabling sub-models via
+  `Detector(identity_model=None)`, batched HOG, etc.). Cross-check `CLAUDE.md`
+  and recent closed issues; if resolved, say so and point to where.
+- **Roadmap awareness:** identity/tracking and real-time work is v0.8
+  (`docs/superpowers/specs/2026-05-02-identity-detection-roadmap.md`);
+  benchmarks and docs migration are in flight. Label such requests as roadmap
+  items rather than asking for more detail.
+- **Labels:** use only labels that already exist (`gh label list`); never
+  invent new ones. At most 2–3 per issue. Don't close issues.
+
+## Cost / scope
+
+Stay focused and bounded — these run on a finite monthly credit pool. Answer
+the question asked; don't expand scope or open large investigations unless a
+maintainer explicitly asks (`@claude` with a specific request).


### PR DESCRIPTION
Adds three Claude Code Action workflows (Max-subscription auth via `CLAUDE_CODE_OAUTH_TOKEN`) + a `REVIEW.md` steering file. Balanced cost posture.

## Workflows
| File | Trigger | Guard | Model / turns |
|---|---|---|---|
| `claude-mention.yml` | issue/PR comment | `@claude` **and** author is OWNER/MEMBER/COLLABORATOR | Sonnet (Opus via `opus` in comment) / 14 |
| `claude-issue-triage.yml` | issue opened | not a bot | Sonnet / 6 |
| `claude-pr-review.yml` | PR opened | **same-repo only** (forks → on-demand `@claude`) | Sonnet / 12 |

## Security (public repo + fork PRs)
- `@claude` is **maintainer-gated** so fork authors can't burn credits or reach the token.
- Auto PR review runs on **same-repo branches only**; fork PRs are reviewed on demand (secrets aren't exposed to fork `pull_request` runs anyway).
- Least-privilege `permissions:` per workflow, `concurrency: cancel-in-progress`, read-only tools (no commits from CI), action pinned to `@v1`.

## ⚠️ Setup required before these do anything (maintainer, one-time)
1. `claude setup-token` (needs your Max sub) → add repo secret `CLAUDE_CODE_OAUTH_TOKEN`.
2. `/install-github-app` (or install https://github.com/apps/claude).

## ⚠️ Default-branch caveat
`issues`- and `issue_comment`-triggered workflows **only fire from the workflow file on the *default* branch (`main`)**. Merging here (v0.7-dev) lets you review the files and activates **PR review** for v0.7-dev PRs, but **mention + triage won't fire until these reach `main`**. Since they're CI infra (not library code, no effect on `pip install` users), landing them on `main` is reasonable — happy to open a main-targeted PR with just these files when you're ready.

## Cost
~$35–80/mo of the $100 Max Agent-SDK credit pool with all three active (Sonnet, capped turns, concurrency-cancel).