### PR TITLE
fix(Detectorv2): isotropic square-pad chip to match v2.5 training geometry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,21 +145,30 @@ imports). Consumers convert to degrees for display only.
   an overlay against a selfie-mirrored video (the mirror flips left/right and
   will send you in circles).
 
-### v2 pitch is compressed — anisotropic chip is the root cause
+### v2 chip geometry — RESOLVED for v2.5 (isotropic square-pad, inference fix)
 
-`Detectorv2`'s pitch reads ~0.4–0.6× of img2pose, and its 478-mesh z axis is
-mis-scaled. Both come from **`extract_face_from_bbox_torch`** squashing the
-rectangular RetinaFace box into a *square* chip with independent x/y scales (plus
-an edge `clamp` instead of pad). This is invisible to v1 (2D landmarks un-squish
-exactly) but destroys v2's chip-space 3D/angle inference. **ConvNeXt V2 is
-size-agnostic** (GAP before every head in `model_v2.py`, ÷32 stride) so the
-square chip is a convention, not a requirement. The interim `[-head0,…]` pose
-map and any "scale z by w/MODEL_INPUT" mesh patch are stopgaps. The real fix —
-an isotropic aspect-preserving (square+pad) chip, used identically for training
-re-extraction and inference, with a full v2 retrain from the IN22k backbone — is
-specced at `docs/superpowers/specs/2026-06-06-v2-chip-extraction-redesign-design.md`.
-Do NOT just tweak signs/scales to paper over the pitch compression; it needs the
-chip fix + retrain.
+History (kept because it explains the code): early `Detectorv2` pitch read
+~0.4–0.6× of img2pose and its 478-mesh z was mis-scaled, because
+**`extract_face_from_bbox_torch`** squashes the rectangular RetinaFace box into a
+*square* chip with independent x/y scales (plus an edge `clamp` instead of pad).
+That's invisible to v1 (2D landmarks un-squish exactly) but corrupts v2's
+chip-space 3D/angle inference. Design spec:
+`docs/superpowers/specs/2026-06-06-v2-chip-extraction-redesign-design.md`.
+
+**This is now fixed.** The shipped v2.5 weights (`py-feat/face_multitask_v2`)
+were already **trained on the isotropic square-pad chip** (au_deep
+`extract_chips_unified.py --v25` → `extract_face_square_pad_torch`,
+`side=max(W,H)·1.2`, reflection-pad, no clamp; mesh targets `[0,1]` over that
+square chip). So no retrain is needed — only the inference path had to match. As
+of the v25-square-pad inference fix, `Detectorv2.detect_faces` /
+`crop_faces_from_boxes` use `extract_face_square_pad_torch` and store the square
+crop region as `new_boxes`, so `_mesh_to_original_frame`'s `[0,1]→box` decode is
+isotropic (`w==h==side`). This removed the 2D mesh-overlay shift (eyes-high /
+mouth-low) and the pitch compression in one change.
+
+`extract_face_from_bbox_torch` is unchanged and **still used by `Detectorv1` and
+`MPDetector`** — their landmark heads invert that squish exactly, so do NOT
+switch them to square-pad. The square-pad crop is v2-only.
 
 ## Repo-specific gotchas
 

--- a/feat/detector_v2.py
+++ b/feat/detector_v2.py
@@ -7,9 +7,12 @@ Outputs a native-v2 :class:`~feat.data.Fex` whose landmark block is
 the dlib-68 subset derived from the 478 mesh (so Fex helpers expecting 68
 points keep working), with the full 478 mesh available in ``mesh_*`` columns.
 
-The model consumes a 256x256 RetinaFace crop (expand_bbox=1.2), exactly as its
-training chips were produced; preprocessing to the 224 model input is handled by
-:class:`~feat.multitask.inference.MultitaskModel`.
+The model consumes a 256x256 RetinaFace crop, produced with the **isotropic
+square-pad** crop (``extract_face_square_pad_torch``, expand_bbox=1.2) — exactly
+the geometry the v2.5 chips were trained on. (v1 ``Detectorv1`` and ``MPDetector``
+keep the legacy anisotropic ``extract_face_from_bbox_torch``; their landmark
+heads invert that squish exactly, so they must not switch.) Preprocessing to the
+224 model input is handled by :class:`~feat.multitask.inference.MultitaskModel`.
 """
 from __future__ import annotations
 
@@ -23,7 +26,7 @@ from torch.utils.data import DataLoader
 from feat.data import Fex, ImageDataset, TensorDataset, VideoDataset
 from feat.utils import set_torch_device
 from feat.utils.image_operations import (
-    extract_face_from_bbox_torch,
+    extract_face_square_pad_torch,
     convert_image_to_tensor,
     convert_bbox_output,
     per_face_padding_inversion_terms,
@@ -53,6 +56,21 @@ from feat.multitask.inference import (
     EXPAND_BBOX,
     _DLIB68_IDX,
 )
+
+
+def _crop_affine_to_box(crop_affine):
+    """``crop_affine`` ``[N,3]`` ``(origin_x, origin_y, side)`` -> square ``[N,4]``
+    ``(x1, y1, x2, y2)``.
+
+    The v2.5 model is trained on the isotropic square-pad chip, so its predicted
+    mesh is normalized [0,1] over a *square* region bounded by
+    ``[origin, origin+side]``. Storing that square as ``new_boxes`` makes the
+    [0,1]->box decode in :meth:`Detectorv2._mesh_to_original_frame` isotropic
+    (``w == h == side``) — the exact inverse of the crop, with no x/y stretch.
+    May extend off-frame (the crop reflection-pads); that is intended.
+    """
+    ox, oy, side = crop_affine[:, 0], crop_affine[:, 1], crop_affine[:, 2]
+    return torch.stack([ox, oy, ox + side, oy + side], dim=-1)
 
 
 class Detectorv2(nn.Module):
@@ -160,12 +178,12 @@ class Detectorv2(nn.Module):
         all_bboxes = self._smooth_bboxes(all_bboxes)
 
         bboxes_for_extract = torch.nan_to_num(all_bboxes, nan=0.0)
-        all_faces, all_new_bboxes = extract_face_from_bbox_torch(
+        all_faces, crop_affine = extract_face_square_pad_torch(
             frames_unit, bboxes_for_extract,
             face_size=self.face_size, expand_bbox=EXPAND_BBOX,
             frame_idx=all_frame_idx,
         )
-        all_new_bboxes = all_new_bboxes.to(torch.float32)
+        all_new_bboxes = _crop_affine_to_box(crop_affine).to(torch.float32)
 
         no_det = torch.isnan(all_bboxes).any(dim=1)
         if no_det.any():
@@ -256,12 +274,12 @@ class Detectorv2(nn.Module):
             torch.arange(B, device=self.device), n_per_frame_t
         )
 
-        all_faces, all_new_bboxes = extract_face_from_bbox_torch(
+        all_faces, crop_affine = extract_face_square_pad_torch(
             frames_unit, all_boxes,
             face_size=self.face_size, expand_bbox=EXPAND_BBOX,
             frame_idx=all_frame_idx,
         )
-        all_new_bboxes = all_new_bboxes.to(torch.float32)
+        all_new_bboxes = _crop_affine_to_box(crop_affine).to(torch.float32)
         all_scores = torch.ones(all_boxes.shape[0], device=self.device)
 
         results, cursor = [], 0
@@ -451,17 +469,19 @@ class Detectorv2(nn.Module):
         """[N,478,3] mesh in normalized [0,1] chip coords -> original-frame coords.
 
         The v2.5 mesh head is trained (deep/losses_v2, deep/augment) to emit
-        coordinates NORMALIZED to [0,1] over the chip — x over chip width, y over
-        chip height. The chip is the expanded (EXPAND_BBOX=1.2) RetinaFace box,
-        resized to the model input, so [0,1] maps directly onto ``new_bboxes``
-        with no extra scale or offset. We then invert the RetinaFace pad+rescale
-        to land in the original frame.
+        coordinates NORMALIZED to [0,1] over the chip. The chip is the **isotropic
+        square-pad** crop (``extract_face_square_pad_torch``), so ``new_bboxes`` is
+        the *square* crop region ``[origin, origin+side]`` (see
+        ``_crop_affine_to_box``). With ``w == h == side`` the [0,1]->box map below
+        is isotropic — the exact inverse of the crop, no x/y stretch — and then we
+        invert the RetinaFace pad+rescale to land in the original frame.
 
-        NB: the legacy decode here was ``mesh / MODEL_INPUT + _CROP_OFFSET /
-        CHIP_SIZE``, which assumed the head output was in 224-pixel units behind a
-        256->224 center-crop. v2.5 changed both: the preprocess is a resize (not a
-        crop) and the mesh target is normalized [0,1]. Applying the old /224 to a
-        [0,1] output collapses the whole mesh to ~0.063 of the box (a dot).
+        This is the deferred v2.5 inference fix: the shipped weights were trained
+        on square-pad chips, but inference had still been feeding the legacy
+        anisotropic ``extract_face_from_bbox_torch`` crop and decoding [0,1] over a
+        rectangular box (independent w/h). That train/inference mismatch shifted
+        the 2D overlay (eyes high / mouth low) and compressed pitch; the square-pad
+        crop + isotropic decode removes both, no retrain.
 
         NB: do the affine directly rather than via
         ``inverse_transform_landmarks_torch`` — that helper reshapes its input as

--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -1217,6 +1217,97 @@ def extract_face_from_bbox_torch(
     return cropped_faces, new_bboxes
 
 
+def extract_face_square_pad_torch(
+    frame, detected_faces, face_size=256, expand_bbox=1.2, frame_idx=None
+):
+    """Isotropic square-pad face crop (Detectorv2 / v2.5 training).
+
+    Forked from ``extract_face_from_bbox_torch`` (which v1 ``Detector`` and
+    ``MPDetector`` still use). That one resizes a rectangular box into a square
+    chip with *independent* x/y scales — it stretches the face, erasing the
+    vertical foreshortening the v2 model needs to infer 3D pose / mesh-depth.
+
+    This version instead:
+      * squares the expanded box to its *longer* side (single scale, no stretch),
+      * resizes isotropically to ``face_size``,
+      * reflect-pads any region that falls outside the source frame (the square
+        is NOT clamped to the frame — off-frame pixels are reflected, so the
+        face stays centred and correctly scaled even at frame edges).
+
+    The crop is a single isotropic affine, so mesh/landmark/pose targets map back
+    to frame coords with one transform and the mesh z-axis stays consistent with
+    x/y. A normalised chip coord ``(u, v) in [0, 1]`` maps to the source frame as
+    ``(origin_x + u * side, origin_y + v * side)``.
+
+    Args:
+        frame: ``[B, C, H, W]`` source frames.
+        detected_faces: ``[N, 4]`` bboxes ``[x1, y1, x2, y2]``.
+        face_size: output spatial size (square).
+        expand_bbox: margin multiplier applied before squaring.
+        frame_idx: ``[N]`` face->frame map (see ``extract_face_from_bbox_torch``).
+
+    Returns:
+        cropped_faces: ``[N, C, face_size, face_size]``.
+        crop_affine: ``[N, 3]`` float ``(origin_x, origin_y, side)`` — the
+            inverse map from normalised chip coords to source-frame pixels.
+    """
+    device = frame.device
+    B, C, H, W = frame.shape
+    N = detected_faces.shape[0]
+    detected_faces = detected_faces.to(device).float()
+
+    x1, y1, x2, y2 = (
+        detected_faces[:, 0],
+        detected_faces[:, 1],
+        detected_faces[:, 2],
+        detected_faces[:, 3],
+    )
+    center_x = (x1 + x2) / 2
+    center_y = (y1 + y2) / 2
+    # Square to the longer side so neither axis is stretched. Unlike the legacy
+    # crop, do NOT clamp the square to the frame — off-frame area is reflected
+    # below, which keeps the face centred + at the right scale near edges.
+    side = torch.maximum((x2 - x1), (y2 - y1)) * expand_bbox
+    side = side.clamp(min=1.0)
+    origin_x = center_x - side / 2
+    origin_y = center_y - side / 2
+    crop_affine = torch.stack([origin_x, origin_y, side], dim=-1)
+
+    # Sample grid: output pixel (i, j) -> source coord origin + (idx+0.5)/face_size*side.
+    yy, xx = torch.meshgrid(
+        torch.arange(face_size, device=device),
+        torch.arange(face_size, device=device),
+        indexing="ij",
+    )
+    yy = yy.float()
+    xx = xx.float()
+    grid_x = origin_x.view(N, 1, 1) + (xx + 0.5) / face_size * side.view(N, 1, 1)
+    grid_y = origin_y.view(N, 1, 1) + (yy + 0.5) / face_size * side.view(N, 1, 1)
+
+    # Normalise to [-1, 1] for grid_sample with align_corners=False: a source
+    # pixel-centre s maps to g = 2*(s+0.5)/W - 1. Using the exact convention (not
+    # the legacy 2*s/(W-1)-1) makes grid_sample sample exactly `grid_x`, so the
+    # returned crop_affine describes the crop with no position-dependent offset.
+    grid_x = 2 * (grid_x + 0.5) / W - 1
+    grid_y = 2 * (grid_y + 0.5) / H - 1
+    grid = torch.stack((grid_x, grid_y), dim=-1).float()
+
+    frame = frame.float()
+    if frame_idx is None:
+        face_indices = torch.arange(N, device=device) % B
+    else:
+        face_indices = frame_idx.to(device=device, dtype=torch.long)
+    frame_expanded = frame[face_indices]
+
+    # reflection padding: off-frame square regions sample mirrored interior pixels
+    # (vs the legacy default 'zeros'), so the GAP-pooled chip isn't diluted by
+    # black borders at frame edges.
+    cropped_faces = F.grid_sample(
+        frame_expanded, grid, padding_mode="reflection", align_corners=False
+    )
+    return cropped_faces, crop_affine
+
+
 def inverse_transform_landmarks_torch(landmarks, boxes):
     """
     Transforms landmarks based on new bounding boxes.


### PR DESCRIPTION
## Symptom
The Detectorv2 478-mesh overlay is systematically off: **too big / over-scaled** (eyes ride high, mouth/chin too low) even with the face fully in frame, **distorted at frame edges**, and **head pitch compressed**.

## Root cause
The shipped v2.5 weights (`py-feat/face_multitask_v2`) were trained on the **isotropic square-pad chip** (`side = max(W,H)·1.2`, reflection-pad, no clamp; mesh targets normalized `[0,1]` over the *square* chip). But inference still fed the **legacy anisotropic** `extract_face_from_bbox_torch` crop (independent x/y scale = stretch) and decoded the mesh `[0,1]` over a *rectangular* box. That train/inference geometry mismatch produces all three symptoms.

## Fix (inference-only, no retrain)
- Add `extract_face_square_pad_torch` (v2-only). Squares to the longer side (single scale, no stretch), resizes isotropically, **reflection-pads** off-frame (face stays centered + correctly scaled at edges), and uses the correct `align_corners=False` sampling convention.
- `Detectorv2.detect_faces` / `crop_faces_from_boxes` extract with square-pad and store the square crop region as `new_boxes`, so the `[0,1]→box` mesh decode is isotropic (`w==h==side`) — the exact inverse of the crop.
- Detectorv1 and MPDetector keep the legacy anisotropic crop (their 2D landmark heads invert that squish exactly).

## Validation
- `test_detector_v2.py` (10) + image-ops/multitask (13) green; re-ran image-ops here (24) all pass.
- **Validated live in Py-feat Live** (dev backend on the square-pad build): the in-frame mesh now fits, the off-frame distortion is gone, and pitch tracks correctly.

Note: this **supersedes** PR #333's off-frame clamp fix *for Detectorv2* (v2 now uses square-pad entirely); the clamp fix still applies to Detectorv1/MPDetector and the two coexist.