### PR TITLE
ci: migrate test workflows from conda to uv + modern Node

### DIFF
--- a/.github/workflows/auto_deploy_on_release.yml
+++ b/.github/workflows/auto_deploy_on_release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
     needs: deploy
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/manual_docs.yml
+++ b/.github/workflows/manual_docs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -65,7 +65,14 @@ jobs:
           fi
 
       - name: Install Dependencies
-        run: uv pip install --system . -r requirements-dev.txt
+        run: |
+          # uv won't install into a uv-managed Python with --system ("No system
+          # Python installation found"), so create an explicit venv and put it on
+          # PATH for later steps (.venv/bin on Linux/macOS, .venv/Scripts on Windows).
+          uv venv --python ${{ matrix.python-version }}
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
+          uv pip install . -r requirements-dev.txt
 
       # Persist HF model downloads across runs. Without this every matrix job
       # pulls retinaface/xgb/resmasknet from the Hub at test-collection time on

--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -18,9 +18,8 @@ jobs:
     # Determines whether the entire workflow should pass/fail based on parallel jobs
     continue-on-error: ${{ matrix.experimental }}
     defaults:
-      # This ensures each step gets properly configured bash shell for conda commands to work
       run:
-        shell: bash -l {0}
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -43,27 +42,30 @@ jobs:
             python-version: "3.13"
             experimental: true
     steps:
-      # Step up miniconda
-      - name: Download and setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
-          python-version: ${{ matrix.python-version }}
-
-      # Check out latest code on github
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      # Install common sci-py packages via conda as well as testing packages and requirements
-      - name: Install Dependencies
+      - name: Install uv + Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      # torchcodec dlopen's FFmpeg's libav* at import time, and the pip xgboost
+      # wheel dlopen's libomp.dylib on macOS. conda used to supply both; with uv
+      # we install them from each runner's OS package manager instead.
+      - name: Install system libraries (FFmpeg, OpenMP)
         run: |
-          conda activate test
-          conda env list
-          # torchcodec dlopen's FFmpeg's libav* at import time; the pip
-          # xgboost wheel dlopen's libomp.dylib on macOS. Install both into
-          # the conda env so the test suite can be collected on all platforms.
-          conda install -c conda-forge -y "ffmpeg<8" llvm-openmp
-          pip install . -r requirements-dev.txt
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y ffmpeg
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install ffmpeg libomp
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install ffmpeg -y
+          fi
+
+      - name: Install Dependencies
+        run: uv pip install --system . -r requirements-dev.txt
 
       # Persist HF model downloads across runs. Without this every matrix job
       # pulls retinaface/xgb/resmasknet from the Hub at test-collection time on
@@ -83,8 +85,6 @@ jobs:
           # (anonymous) if the secret isn't set.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          conda activate test
-          conda env list
           ruff check --ignore=W292,E402,E501,E731,E741 feat
           pytest --cov=feat -rs
 

--- a/.github/workflows/tests_on_pr.yml
+++ b/.github/workflows/tests_on_pr.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests_on_pr.yml
+++ b/.github/workflows/tests_on_pr.yml
@@ -16,9 +16,8 @@ jobs:
     # Determines whether the entire workflow should pass/fail based on parallel jobs
     continue-on-error: ${{ matrix.experimental }}
     defaults:
-      # This ensures each step gets properly configured bash shell for conda commands to work
       run:
-        shell: bash -l {0}
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -41,27 +40,30 @@ jobs:
             python-version: "3.13"
             experimental: true
     steps:
-      # Step up miniconda
-      - name: Download and setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
-          python-version: ${{ matrix.python-version }}
-
-      # Check out latest code on github
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      # Install common sci-py packages via conda as well as testing packages and requirements
-      - name: Install Dependencies
+      - name: Install uv + Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      # torchcodec dlopen's FFmpeg's libav* at import time, and the pip xgboost
+      # wheel dlopen's libomp.dylib on macOS. conda used to supply both; with uv
+      # we install them from each runner's OS package manager instead.
+      - name: Install system libraries (FFmpeg, OpenMP)
         run: |
-          conda activate test
-          conda env list
-          # torchcodec dlopen's FFmpeg's libav* at import time; the pip
-          # xgboost wheel dlopen's libomp.dylib on macOS. Install both into
-          # the conda env so the test suite can be collected on all platforms.
-          conda install -c conda-forge -y "ffmpeg<8" llvm-openmp
-          pip install . -r requirements-dev.txt
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y ffmpeg
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install ffmpeg libomp
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            choco install ffmpeg -y
+          fi
+
+      - name: Install Dependencies
+        run: uv pip install --system . -r requirements-dev.txt
 
       # Persist HF model downloads across runs. Without this every matrix job
       # pulls retinaface/xgb/resmasknet from the Hub at test-collection time on
@@ -81,8 +83,6 @@ jobs:
           # (anonymous) if the secret isn't set.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          conda activate test
-          conda env list
           ruff check --ignore=W292,E402,E501,E731,E741 feat
           pytest --cov=feat -rs
 

--- a/.github/workflows/tests_on_pr.yml
+++ b/.github/workflows/tests_on_pr.yml
@@ -63,7 +63,14 @@ jobs:
           fi
 
       - name: Install Dependencies
-        run: uv pip install --system . -r requirements-dev.txt
+        run: |
+          # uv won't install into a uv-managed Python with --system ("No system
+          # Python installation found"), so create an explicit venv and put it on
+          # PATH for later steps (.venv/bin on Linux/macOS, .venv/Scripts on Windows).
+          uv venv --python ${{ matrix.python-version }}
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
+          uv pip install . -r requirements-dev.txt
 
       # Persist HF model downloads across runs. Without this every matrix job
       # pulls retinaface/xgb/resmasknet from the Hub at test-collection time on

--- a/.gitignore
+++ b/.gitignore
@@ -121,8 +121,6 @@ dev/
 # CPU/GPU profiling script
 gpu_profiling.py
 
-environment.yml
-
 # Longer video
 FNL_01.mp4
 


### PR DESCRIPTION
## What

Replaces the conda-based CI with **uv** and bumps every `actions/checkout` to **v4** (modern Node).

### Why
PR #334's CI failed in the conda **Install Dependencies** step (`conda install -c conda-forge ffmpeg<8 llvm-openmp` → exit 2, a conda-forge resolution flake), and the run flagged Node deprecation on `actions/checkout@v2` + `conda-incubator/setup-miniconda@v3` (GitHub forces Node 24 on 2026-06-16). py-feat dev already moved fully to uv on v0.7-dev; this brings CI in line and fixes both.

### Changes
- **`tests_on_pr.yml` / `tests_and_docs.yml` test jobs**: `setup-miniconda` → `astral-sh/setup-uv@v6` + `uv pip install --system`. The two libs conda supplied — **FFmpeg** (torchcodec dlopen's libav*) and **OpenMP/libomp** (xgboost on macOS) — now come from the OS package manager (apt/brew/choco).
- **`actions/checkout@v2` → `@v4`** across all workflows (modern Node).
- Drop the dead `environment.yml` `.gitignore` entry.

### Validation
This PR's own CI runs the new uv workflow — that's the validation. Once green, merge → then #334 (square-pad fix) picks it up from v0.7-dev.

### Note
macOS brew ffmpeg is currently 7.x (the conda pin was `ffmpeg<8`); watch the first macOS run.