### PR TITLE
docs: fix broken /models.md link in Detecting_Images tutorial

### DIFF
--- a/docs/_rendered/basic_tutorials/Detecting_Images.md
+++ b/docs/_rendered/basic_tutorials/Detecting_Images.md
@@ -13,7 +13,7 @@ The recommended way to extract facial features in Py-Feat 0.7+ is **`Detectorv2`
 
 The first time you initialize a detector, Py-Feat downloads the required pretrained weights from [our HuggingFace Repository](https://huggingface.co/py-feat) and caches them to disk; subsequent runs reuse the cached weights.
 
-You can find a list of default models [on this page](/models.md). For the older modular detector, see the [legacy `Detectorv1` (v1)](#legacy-the-modular-detectorv1-v1) section just below.
+You can find a list of default models [on this page](../pages/models.md). For the older modular detector, see the [legacy `Detectorv1` (v1)](#legacy-the-modular-detectorv1-v1) section just below.
 
 ```python
 from feat import Detectorv2

--- a/docs/basic_tutorials/Detecting_Images.py
+++ b/docs/basic_tutorials/Detecting_Images.py
@@ -47,7 +47,7 @@ def _(mo):
 
     The first time you initialize a detector, Py-Feat downloads the required pretrained weights from [our HuggingFace Repository](https://huggingface.co/py-feat) and caches them to disk; subsequent runs reuse the cached weights.
 
-    You can find a list of default models [on this page](/models.md). For the older modular detector, see the [legacy `Detectorv1` (v1)](#legacy-the-modular-detectorv1-v1) section just below.
+    You can find a list of default models [on this page](../pages/models.md). For the older modular detector, see the [legacy `Detectorv1` (v1)](#legacy-the-modular-detectorv1-v1) section just below.
     """)
     return
 


### PR DESCRIPTION
The only genuinely-broken link surfaced when deploying the marimo book: `[on this page](/models.md)` 404s (the page builds at `/pages/models/`). Switched to the mkdocs source-relative form `../pages/models.md` (validated + resolved by mkdocs on any base). Fixed in both `Detecting_Images.py` and its `_rendered/` copy.

The live site was already hot-patched in this deploy; this makes it permanent for future builds.