### PR TITLE
docs: strengthen Performance tutorial (batching + pin_memory)

### DIFF
--- a/docs/_rendered/basic_tutorials/Performance.md
+++ b/docs/_rendered/basic_tutorials/Performance.md
@@ -47,8 +47,8 @@ detector.detect(img_path, data_type="image")
 print(f"single-image detect: {time.perf_counter() - _t0:.3f}s on {device}")
 ```
 
-<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:02&lt;00:00,  2.67s/it]100%|██████████| 1/1 [00:02&lt;00:00,  2.67s/it]
-  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 37.41it/s]
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:02&lt;00:00,  2.64s/it]100%|██████████| 1/1 [00:02&lt;00:00,  2.64s/it]
+  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 37.09it/s]
 </pre>
 
 <pre class="marimo-book-output-text marimo-stream-stdout">single-image detect: 0.029s on cuda
@@ -56,43 +56,101 @@ print(f"single-image detect: {time.perf_counter() - _t0:.3f}s on {device}")
 
 ## 6.3 Batch images and video
 
-Processing inputs one at a time leaves the GPU idle between calls. Pass
-`batch_size > 1` to stack inputs into a single tensor — a large speedup on
-a GPU.
+Batching is the single biggest lever on GPU throughput. Processing inputs
+one at a time leaves the GPU idle between calls; passing `batch_size > 1`
+stacks inputs into one tensor so the network runs them in parallel. The
+sweep below shows throughput (images/second) climbing with batch size —
+**pick the largest batch that fits in VRAM** (drop it back down if you hit
+an out-of-memory error).
 
 - **Images:** `detector.detect(img_list, batch_size=8)`. All images in a
-  batch must share dimensions; pass `output_size=...` to pad/resize
-  mismatched images.
+  batch must share dimensions; pass `output_size=(H, W)` to pad/resize
+  mismatched images so they stack.
 - **Video:** `detector.detect(video, data_type="video", batch_size=8)`.
   Add `skip_frames=N` to process every *N*-th frame when you don't need
-  every frame.
+  every frame — see the *Detecting Videos* tutorial for a full example.
 
 ```python
 multi = os.path.join(get_test_data_path(), "multi_face.jpg")
 img_list = [multi] * 8
 
-for _bs in (1, 8):
+for _bs in (1, 2, 4, 8):
     detector.detect(img_list, batch_size=_bs, data_type="image")  # warmup
     _t0 = time.perf_counter()
     detector.detect(img_list, batch_size=_bs, data_type="image")
-    print(f"8 images, batch_size={_bs}: {time.perf_counter() - _t0:.3f}s")
+    _dt = time.perf_counter() - _t0
+    print(f"8 images, batch_size={_bs}: {_dt:.3f}s ({8 / _dt:.1f} img/s)")
 ```
 
-<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/8 [00:00&lt;?, ?it/s] 12%|█▎        | 1/8 [00:01&lt;00:10,  1.57s/it] 62%|██████▎   | 5/8 [00:01&lt;00:00,  3.85it/s]100%|██████████| 8/8 [00:01&lt;00:00,  4.49it/s]
-  0%|          | 0/8 [00:00&lt;?, ?it/s] 50%|█████     | 4/8 [00:00&lt;00:00, 32.10it/s]100%|██████████| 8/8 [00:00&lt;00:00, 32.39it/s]100%|██████████| 8/8 [00:00&lt;00:00, 32.30it/s]
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/8 [00:00&lt;?, ?it/s] 12%|█▎        | 1/8 [00:01&lt;00:10,  1.56s/it] 62%|██████▎   | 5/8 [00:01&lt;00:00,  3.86it/s]100%|██████████| 8/8 [00:01&lt;00:00,  4.50it/s]
+  0%|          | 0/8 [00:00&lt;?, ?it/s] 50%|█████     | 4/8 [00:00&lt;00:00, 32.47it/s]100%|██████████| 8/8 [00:00&lt;00:00, 32.31it/s]100%|██████████| 8/8 [00:00&lt;00:00, 32.29it/s]
 </pre>
 
-<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=1: 0.253s
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=1: 0.252s (31.7 img/s)
 </pre>
 
-<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:03&lt;00:00,  3.81s/it]100%|██████████| 1/1 [00:03&lt;00:00,  3.81s/it]
-  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 10.44it/s]
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/4 [00:00&lt;?, ?it/s] 25%|██▌       | 1/4 [00:03&lt;00:11,  3.76s/it]100%|██████████| 4/4 [00:03&lt;00:00,  1.35it/s]100%|██████████| 4/4 [00:03&lt;00:00,  1.03it/s]
+  0%|          | 0/4 [00:00&lt;?, ?it/s] 75%|███████▌  | 3/4 [00:00&lt;00:00, 26.89it/s]100%|██████████| 4/4 [00:00&lt;00:00, 26.78it/s]
 </pre>
 
-<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=8: 0.098s
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=2: 0.153s (52.3 img/s)
 </pre>
 
-## 6.4 Leave `num_workers=0`
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/2 [00:00&lt;?, ?it/s] 50%|█████     | 1/2 [00:03&lt;00:03,  3.76s/it]100%|██████████| 2/2 [00:03&lt;00:00,  1.90s/it]
+  0%|          | 0/2 [00:00&lt;?, ?it/s]100%|██████████| 2/2 [00:00&lt;00:00, 19.48it/s]100%|██████████| 2/2 [00:00&lt;00:00, 19.41it/s]
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=4: 0.107s (75.1 img/s)
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:03&lt;00:00,  3.78s/it]100%|██████████| 1/1 [00:03&lt;00:00,  3.78s/it]
+  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 10.46it/s]
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=8: 0.098s (81.3 img/s)
+</pre>
+
+## 6.4 Pin memory for faster CUDA transfers
+
+Every batch is copied from host (CPU) RAM into GPU memory before the
+network runs. On **CUDA**, passing `pin_memory=True` allocates that batch
+in *page-locked* host memory, which lets the copy overlap with computation
+— Py-Feat already issues the host→device transfer with `non_blocking=True`,
+so the two halves pair up for a small, free win on GPU-bound batches.
+
+`pin_memory` has no effect on **MPS** or **CPU** (there's no pinned-memory
+fast path), so only set it when `device="cuda"`.
+
+```python
+if device == "cuda":
+    for _pin in (False, True):
+        detector.detect(
+            img_list, batch_size=8, pin_memory=_pin, data_type="image"
+        )  # warmup
+        _t0 = time.perf_counter()
+        detector.detect(
+            img_list, batch_size=8, pin_memory=_pin, data_type="image"
+        )
+        print(f"8 images, batch_size=8, pin_memory={_pin}: {time.perf_counter() - _t0:.3f}s")
+else:
+    print(f"pin_memory only affects CUDA; current device is {device!r} — skipping.")
+```
+
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 11.18it/s]
+  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 11.38it/s]
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=8, pin_memory=False: 0.090s
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stderr">  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 10.13it/s]
+  0%|          | 0/1 [00:00&lt;?, ?it/s]100%|██████████| 1/1 [00:00&lt;00:00, 11.42it/s]
+</pre>
+
+<pre class="marimo-book-output-text marimo-stream-stdout">8 images, batch_size=8, pin_memory=True: 0.090s
+</pre>
+
+## 6.5 Leave `num_workers=0`
 
 `detect()` accepts a DataLoader `num_workers` argument. **Keep the default
 `num_workers=0`.** On Apple Silicon + Python 3.13 with Py-Feat's
@@ -101,7 +159,7 @@ for _bs in (1, 8):
 the same single-threaded BLAS/OMP pool. If a DataLoader feels slow, this
 is usually why.
 
-## 6.5 Large datasets
+## 6.6 Large datasets
 
 - Pass `save="out.csv"` to write results incrementally instead of holding
   every frame in memory.

--- a/docs/_rendered/manifest.json
+++ b/docs/_rendered/manifest.json
@@ -25,8 +25,8 @@
       "body_path": "basic_tutorials/Performance.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T02:37:51+00:00",
-      "src_hash": "dc8e25a161d8d6bbbaa4e57976c45a8880256af9b7e020cc03ea958bdf81104c"
+      "rendered_at": "2026-06-15T03:32:00+00:00",
+      "src_hash": "426604bc32e2edacfc3ae29dd6594898ffdcd2d98aa06a5c58ffde32cfba1cc1"
     },
     "basic_tutorials/Plotting.py": {
       "body_path": "basic_tutorials/Plotting.md",

--- a/docs/basic_tutorials/Performance.py
+++ b/docs/basic_tutorials/Performance.py
@@ -100,16 +100,19 @@ def _(mo):
         r"""
         ## 6.3 Batch images and video
 
-        Processing inputs one at a time leaves the GPU idle between calls. Pass
-        `batch_size > 1` to stack inputs into a single tensor — a large speedup on
-        a GPU.
+        Batching is the single biggest lever on GPU throughput. Processing inputs
+        one at a time leaves the GPU idle between calls; passing `batch_size > 1`
+        stacks inputs into one tensor so the network runs them in parallel. The
+        sweep below shows throughput (images/second) climbing with batch size —
+        **pick the largest batch that fits in VRAM** (drop it back down if you hit
+        an out-of-memory error).
 
         - **Images:** `detector.detect(img_list, batch_size=8)`. All images in a
-          batch must share dimensions; pass `output_size=...` to pad/resize
-          mismatched images.
+          batch must share dimensions; pass `output_size=(H, W)` to pad/resize
+          mismatched images so they stack.
         - **Video:** `detector.detect(video, data_type="video", batch_size=8)`.
           Add `skip_frames=N` to process every *N*-th frame when you don't need
-          every frame.
+          every frame — see the *Detecting Videos* tutorial for a full example.
         """
     )
     return
@@ -120,11 +123,48 @@ def _(detector, get_test_data_path, os, time):
     multi = os.path.join(get_test_data_path(), "multi_face.jpg")
     img_list = [multi] * 8
 
-    for _bs in (1, 8):
+    for _bs in (1, 2, 4, 8):
         detector.detect(img_list, batch_size=_bs, data_type="image")  # warmup
         _t0 = time.perf_counter()
         detector.detect(img_list, batch_size=_bs, data_type="image")
-        print(f"8 images, batch_size={_bs}: {time.perf_counter() - _t0:.3f}s")
+        _dt = time.perf_counter() - _t0
+        print(f"8 images, batch_size={_bs}: {_dt:.3f}s ({8 / _dt:.1f} img/s)")
+    return (img_list,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        ## 6.4 Pin memory for faster CUDA transfers
+
+        Every batch is copied from host (CPU) RAM into GPU memory before the
+        network runs. On **CUDA**, passing `pin_memory=True` allocates that batch
+        in *page-locked* host memory, which lets the copy overlap with computation
+        — Py-Feat already issues the host→device transfer with `non_blocking=True`,
+        so the two halves pair up for a small, free win on GPU-bound batches.
+
+        `pin_memory` has no effect on **MPS** or **CPU** (there's no pinned-memory
+        fast path), so only set it when `device="cuda"`.
+        """
+    )
+    return
+
+
+@app.cell
+def _(detector, device, img_list, time):
+    if device == "cuda":
+        for _pin in (False, True):
+            detector.detect(
+                img_list, batch_size=8, pin_memory=_pin, data_type="image"
+            )  # warmup
+            _t0 = time.perf_counter()
+            detector.detect(
+                img_list, batch_size=8, pin_memory=_pin, data_type="image"
+            )
+            print(f"8 images, batch_size=8, pin_memory={_pin}: {time.perf_counter() - _t0:.3f}s")
+    else:
+        print(f"pin_memory only affects CUDA; current device is {device!r} — skipping.")
     return
 
 
@@ -132,7 +172,7 @@ def _(detector, get_test_data_path, os, time):
 def _(mo):
     mo.md(
         r"""
-        ## 6.4 Leave `num_workers=0`
+        ## 6.5 Leave `num_workers=0`
 
         `detect()` accepts a DataLoader `num_workers` argument. **Keep the default
         `num_workers=0`.** On Apple Silicon + Python 3.13 with Py-Feat's
@@ -141,7 +181,7 @@ def _(mo):
         the same single-threaded BLAS/OMP pool. If a DataLoader feels slow, this
         is usually why.
 
-        ## 6.5 Large datasets
+        ## 6.6 Large datasets
 
         - Pass `save="out.csv"` to write results incrementally instead of holding
           every frame in memory.


### PR DESCRIPTION
Sharpens the Performance tutorial's batching guidance and adds a CUDA `pin_memory` section. Already Detectorv2-focused with no Colab cells.

## Changes

- **6.3 Batching** — expanded the demo to a 1/2/4/8 batch-size sweep that reports throughput (images/second), so the GPU win is legible. Prose now frames batching as the biggest throughput lever and recommends the largest batch that fits VRAM. On this CUDA box: 31.7 → 81.3 img/s from batch_size 1 → 8.
- **6.4 Pin memory (new)** — `pin_memory=True` allocates each batch in page-locked host memory, which pairs with Py-Feat's existing `non_blocking=True` host→device transfer (`detector_v2.py:139,236`) to overlap the copy with compute. CUDA-only; documented as a no-op on MPS/CPU. Includes a CUDA-gated before/after timing cell.
- Renumbered the following sections (`num_workers` → 6.5, large datasets → 6.6).

## Validation

- `Detectorv2.detect` confirmed to accept `pin_memory`, `skip_frames`, `num_workers`, `batch_size`, `output_size`.
- `marimo-book render --check` → all 6 cached pages up to date (only Performance re-rendered; other tutorials' render noise reverted).
- `marimo-book build` → clean.