### PR TITLE
packaging: exclude HuggingFace model cache from the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,9 @@ recursive-include tutorials *.ipynb
 recursive-include feat *
 global-exclude *.pth *.tar *.yaml *.zip *.npy *.xml *fer_* *.joblib
 global-exclude */.ipynb_checkpoints/* *.py[co] __pycache__ .DS_Store
+# Never ship the lazily-downloaded HuggingFace model cache (models are fetched
+# to feat/resources/ at runtime). Without this, building an sdist from a
+# checkout that has already run a detector produces a multi-GB tarball that
+# PyPI rejects.
+prune feat/resources/models--*
+prune feat/resources/.locks


### PR DESCRIPTION
**Found while verifying the v2.0.0 build.** Running `python -m build --sdist` produced a **3.3 GB** source tarball — PyPI would reject it (per-file limit ~100 MB), failing the release workflow's PyPI publish step.

## Cause

`MANIFEST.in` has `recursive-include feat *`, which is evaluated against the **filesystem**, not git. The lazily-downloaded HuggingFace model cache lives under `feat/resources/models--*/` (gitignored, fetched at runtime by `hf_hub_download`). On any checkout that has already run a detector, that cache is on disk, so the sdist swept in ~3.3 GB of model weights. Gitignore doesn't help here — it keeps the cache out of the repo but has no effect on sdist assembly.

A fresh CI checkout wouldn't have the cache, so CI happened to build clean — but the packaging is a footgun for anyone building locally, and it shouldn't depend on the build environment being pristine.

## Fix

`prune feat/resources/models--*` and `prune feat/resources/.locks` in `MANIFEST.in`. Models are still downloaded at runtime exactly as before.

## Verification

- Before: `py_feat-2.0.0.tar.gz` = **3.3 GB** (526 MB resmasknet blob, etc.).
- After: **11 MB**, zero `models--` entries; largest remaining files are legitimate test fixtures. Wheel unchanged (11.5 MB). `twine check` passes.