### PR TITLE
Dense-mesh AU & blendshape region overlays (plot_face_regions)

### DIFF
--- a/feat/data.py
+++ b/feat/data.py
@@ -32,6 +32,7 @@ from feat.utils import flatten_list
 from feat.utils.io import read_feat, read_openface, load_pil_img
 from feat.plotting import (
     plot_face,
+    plot_face_regions,
     draw_lineface,
     draw_facepose,
     draw_facegaze,
@@ -1810,9 +1811,13 @@ class Fex(DataFrame):
 
 
         Args:
-            faces (str, optional): 'landmarks' to draw detected landmarks or 'aus' to
-            generate a face from AU detections using Py-Feat's AU landmark model.
-            Defaults to 'landmarks'.
+            faces (str, optional): 'landmarks' to draw detected landmarks on the
+            image; 'aus' to generate a synthetic face from AU detections using
+            Py-Feat's AU landmark model; 'au_regions' / 'blendshape_regions' to
+            shade the dense-mesh AU / ARKit-blendshape regions
+            (feat.plotting.plot_face_regions) by this frame's detected
+            intensities. ('blendshape_regions' needs a Detectorv2 / MPDetector
+            detection.) Defaults to 'landmarks'.
             faceboxes (bool, optional): Whether to draw the bounding box around detected
             faces. Only applies if faces='landmarks'. Defaults to True.
             muscles (bool, optional): Whether to draw muscles from AU activity. Only
@@ -1873,7 +1878,12 @@ class Fex(DataFrame):
                 if face_ax is not None:
                     facebox = row[self.facebox_columns].values
 
-                    if not faces == "aus" and plot_original_image:
+                    # 'aus' + the region overlays draw a synthetic face in their
+                    # own coord system, so (like 'aus') they skip the original
+                    # image and the bbox/pose/gaze overlays anchored to it.
+                    synthetic_mode = faces in ("aus", "au_regions", "blendshape_regions")
+
+                    if not synthetic_mode and plot_original_image:
                         file_extension = os.path.basename(row["input"]).split(".")[-1]
                         if file_extension.lower() in [
                             "jpg",
@@ -1898,8 +1908,9 @@ class Fex(DataFrame):
                     # gaze overlays don't align with it and just confuse
                     # the picture. Skip them in aus mode — gaze is still
                     # rendered on the synthetic face via plot_face's
-                    # gaze= kwarg (handled by _prepare_plot_aus).
-                    aus_mode = faces == "aus"
+                    # gaze= kwarg (handled by _prepare_plot_aus). The region
+                    # overlays are synthetic too, so they share this skip.
+                    aus_mode = synthetic_mode
 
                     if faceboxes and not aus_mode:
                         rect = Rectangle(
@@ -1976,9 +1987,45 @@ class Fex(DataFrame):
                             muscles=muscles,
                             title=None,
                         )
+
+                    elif faces in ("au_regions", "blendshape_regions"):
+                        # Dense-mesh region overlay (feat.plotting.plot_face_regions)
+                        # coloured by this row's detected intensities, drawn on the
+                        # canonical mesh. (For an on-image / live-video overlay on a
+                        # detected 478-mesh, call plot_face_regions(landmarks=...).)
+                        if any(self.groupby("frame").size() > 1):
+                            raise NotImplementedError(
+                                "Region overlays are not currently supported for "
+                                "detections that contain multiple faces"
+                            )
+                        from feat.utils.region_maps import (
+                            load_au_region_map,
+                            load_blendshape_region_map,
+                        )
+
+                        if faces == "au_regions":
+                            kind = "au"
+                            region_names = load_au_region_map().keys()
+                        else:
+                            kind = "blendshape"
+                            if not self.blendshape_columns:
+                                raise ValueError(
+                                    "faces='blendshape_regions' requires blendshape "
+                                    "detections (Detectorv2 / MPDetector)."
+                                )
+                            region_names = load_blendshape_region_map().keys()
+                        values = {
+                            name: float(row[name])
+                            for name in region_names
+                            if name in row.index
+                        }
+                        face_ax = plot_face_regions(
+                            values=values, kind=kind, ax=face_ax
+                        )
                     else:
                         raise ValueError(
-                            f"faces={type(faces)} is not currently supported try ['False','landmarks','aus']."
+                            f"faces={type(faces)} is not currently supported try "
+                            "['False','landmarks','aus','au_regions','blendshape_regions']."
                         )
 
                     if add_titles:

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -1377,6 +1377,12 @@ def plot_face_regions(
         base_xy = np.asarray(landmarks, dtype=np.float64)[:, :2]
         if len(base_xy) < n_base:
             raise ValueError(f"landmarks must have >= {n_base} vertices")
+        # The subdivision topology (parents/tris) is built on the n_base-vertex
+        # canonical mesh, with midpoint indices starting at n_base. A detected
+        # MediaPipe mesh has 478 verts (the trailing 10 are iris, unused by the
+        # regions), so trim to n_base — otherwise dense_positions seeds with the
+        # iris rows and every midpoint index is shifted, scrambling the overlay.
+        base_xy = base_xy[:n_base]
     xy = rm.dense_positions(base_xy, parents)
 
     # normalize `values` -> {region: intensity}

--- a/feat/plotting.py
+++ b/feat/plotting.py
@@ -10,6 +10,7 @@ import numpy as np
 from sklearn.cross_decomposition import PLSRegression
 from sklearn import __version__ as skversion
 import matplotlib.pyplot as plt
+from matplotlib.collections import PolyCollection, LineCollection
 from feat.pretrained import AU_LANDMARK_MAP
 from feat.utils.io import get_resource_path, download_url
 from feat.utils.image_operations import (
@@ -37,6 +38,7 @@ from torchvision.utils import draw_keypoints, draw_bounding_boxes, make_grid
 __all__ = [
     "draw_lineface",
     "plot_face",
+    "plot_face_regions",
     "draw_vectorfield",
     "draw_muscles",
     "get_heat",
@@ -1292,6 +1294,165 @@ def imshow(obj, figsize=(3, 3), aspect="equal"):
     _, ax = plt.subplots(figsize=figsize)
     _ = ax.imshow(obj, aspect=aspect)
     _ = ax.axis("off")
+    return ax
+
+
+def _region_map_colors(kind, regions):
+    """Distinct per-region colors for the 'map view' (no intensities). AU regions
+    get one hue each; blendshape regions share their AU's hue with Left lighter /
+    Right darker / center mid, so the independent L/R footprints read clearly."""
+    from feat.utils import region_maps as rm
+
+    if kind == "au":
+        cm = plt.get_cmap("tab20").resampled(max(len(regions), 1))
+        return {r: cm(i) for i, r in enumerate(sorted(regions))}
+    aus = sorted({rm.BLENDSHAPE_SEEDS[r][0] for r in regions if r in rm.BLENDSHAPE_SEEDS})
+    cm = plt.get_cmap("tab20").resampled(max(len(aus), 1))
+    hue = {au: cm(i)[:3] for i, au in enumerate(aus)}
+    out = {}
+    for r in regions:
+        au, _muscle, side, _seeds = rm.BLENDSHAPE_SEEDS.get(r, ("", "", "C", []))
+        h, _s, _v = colors.rgb_to_hsv(hue.get(au, (0.5, 0.5, 0.5)))
+        val = {"L": 0.95, "R": 0.6}.get(side, 0.78)
+        out[r] = (*colors.hsv_to_rgb([h, _s, val]), 1.0)
+    return out
+
+
+def plot_face_regions(
+    values=None,
+    kind="au",
+    landmarks=None,
+    ax=None,
+    cmap="Reds",
+    alpha=0.9,
+    region_colors=None,
+    mesh=True,
+    title=None,
+    figsize=(5, 6),
+):
+    """Overlay AU or ARKit-blendshape regions on the MediaPipe-478 mesh.
+
+    The dense-mesh, non-overlapping successor to ``plot_face(muscles=True)``.
+    Regions come from ``feat.utils.region_maps`` (a non-overlapping geodesic-
+    Voronoi partition of the mesh) and are filled as smooth per-triangle patches
+    on a subdivided mesh. Works on the canonical mesh (a legend/key) or on a
+    detected 478-mesh (a live overlay).
+
+    Args:
+        values: ``None`` → map view (every region a distinct color). Otherwise a
+            ``{region_name: intensity}`` dict or a 1-D array aligned to the map's
+            region order; intensities are clipped to ``[0, 1]`` and drive the
+            colormap. Regions with intensity ``<= 0`` are not drawn.
+        kind: ``"au"`` (AUs, L+R merged) or ``"blendshape"`` (L/R independent);
+            both are non-overlapping partitions.
+        landmarks: optional detected mesh ``(>=468, 2|3)`` in image coords to
+            overlay on; default uses the upright canonical mesh.
+        ax: matplotlib axis; created if ``None``.
+        cmap: colormap used when ``values`` is given.
+        region_colors: optional ``{region: color}`` override for the map view.
+        mesh: draw the faint mesh wireframe behind the regions (canonical view only).
+
+    Returns:
+        ax: the matplotlib axis.
+    """
+    from feat.utils import region_maps as rm
+
+    if kind == "au":
+        region_map = rm.load_au_region_map()
+    elif kind == "blendshape":
+        region_map = rm.load_blendshape_region_map()
+    else:
+        raise ValueError(f"kind must be 'au' or 'blendshape', got {kind!r}")
+    order = list(region_map.keys())
+
+    assets = rm.render_assets(kind)
+    parents, tris, region_verts = assets["parents"], assets["tris"], assets["region_verts"]
+    n_base = assets["n_base"]
+
+    on_canonical = landmarks is None
+    if on_canonical:
+        V, _ = rm._canonical_geometry()
+        base_xy = rm.project_xy(V)
+    else:
+        base_xy = np.asarray(landmarks, dtype=np.float64)[:, :2]
+        if len(base_xy) < n_base:
+            raise ValueError(f"landmarks must have >= {n_base} vertices")
+    xy = rm.dense_positions(base_xy, parents)
+
+    # normalize `values` -> {region: intensity}
+    if values is None:
+        vals = {r: 1.0 for r in order}
+        colmap = region_colors or _region_map_colors(kind, order)
+    else:
+        if isinstance(values, dict):
+            vals = {r: float(values.get(r, 0.0)) for r in order}
+        else:
+            v = np.asarray(values, dtype=np.float64).ravel()
+            if len(v) != len(order):
+                raise ValueError(f"values length {len(v)} != {len(order)} regions")
+            vals = dict(zip(order, v))
+        cm = plt.get_cmap(cmap)
+        colmap = {r: cm(float(np.clip(vals[r], 0, 1))) for r in order}
+
+    if ax is None:
+        ax = _create_empty_figure(figsize=figsize, xlim=None, ylim=None)
+        host_had_data = False
+    else:
+        host_had_data = ax.has_data()
+
+    if mesh and on_canonical:
+        edges = np.array(sorted({tuple(sorted((int(a), int(b))))
+                                 for t in tris for a, b in
+                                 ((t[0], t[1]), (t[1], t[2]), (t[0], t[2]))}))
+        ax.add_collection(LineCollection(xy[edges], colors="0.85", linewidths=0.2,
+                                         zorder=1))
+
+    # For blendshapes the region_verts are keyed by FEATURE (L/R merged); a
+    # sided blendshape fills only the triangles of its feature whose centroid
+    # falls on its side of the midline — dividing L/R cleanly down the middle.
+    axis = assets["axis"]
+    cx = xy[tris].mean(axis=1)[:, 0] if kind == "blendshape" else None
+
+    for region in sorted(order, key=lambda r: vals[r]):
+        if vals[region] <= 0:
+            continue
+        if kind == "blendshape":
+            verts = region_verts.get(rm._feature_of(region), set())
+            side = rm.BLENDSHAPE_SEEDS[region][2]
+        else:
+            verts, side = region_verts.get(region, set()), "C"
+        if not verts:
+            continue
+        polys = []
+        for i, tri in enumerate(tris):
+            if sum(v in verts for v in tri) < 2:
+                continue
+            if side == "L" and cx[i] <= axis:      # subject-left = x > midline
+                continue
+            if side == "R" and cx[i] >= axis:
+                continue
+            polys.append(xy[tri])
+        if polys:
+            ax.add_collection(PolyCollection(polys, facecolors=colmap[region],
+                                             edgecolors="none", alpha=alpha, zorder=3))
+
+    if not host_had_data:
+        xmin, ymin = xy.min(0)
+        xmax, ymax = xy.max(0)
+        px, py = (xmax - xmin) * 0.06, (ymax - ymin) * 0.06
+        ax.set_xlim(xmin - px, xmax + px)
+        # project_xy already orients the canonical mesh upright (forehead at
+        # large y), so use ascending limits. A detected mesh handed in is in
+        # image coords (y grows downward) — invert so it isn't upside-down.
+        if on_canonical:
+            ax.set_ylim(ymin - py, ymax + py)
+        else:
+            ax.set_ylim(ymax + py, ymin - py)
+        ax.set_aspect("equal", adjustable="box")
+    ax.axes.get_xaxis().set_visible(False)
+    ax.axes.get_yaxis().set_visible(False)
+    if title is not None:
+        ax.set_title(title)
     return ax
 
 

--- a/feat/resources/au_region_map.json
+++ b/feat/resources/au_region_map.json
@@ -1,0 +1,602 @@
+{
+  "_meta": {
+    "description": "Non-overlapping AU region overlay on the MediaPipe-478 mesh. Winner-take-all geodesic-Voronoi partition of the bundled canonical mesh, walled off by the eye/mouth aperture rings.",
+    "kind": "AU",
+    "n_regions": 19,
+    "tightness": 0.1,
+    "mesh": "feat/resources/canonical_face_model.pt (468 verts)",
+    "generator": "scripts/build_region_maps.py",
+    "sources": [
+      "FACS (Ekman & Friesen)",
+      "melindaozel.com/arkit-to-facs-cheat-sheet",
+      "pooyadeperson.com ARKit-52 anatomy guide"
+    ]
+  },
+  "regions": {
+    "AU01": {
+      "muscles": [
+        "frontalis_inner_L",
+        "frontalis_inner_R"
+      ],
+      "mp478_vertices": [
+        52,
+        66,
+        67,
+        69,
+        105,
+        108,
+        109,
+        282,
+        296,
+        297,
+        299,
+        334,
+        337,
+        338
+      ],
+      "n_vertices": 14
+    },
+    "AU02": {
+      "muscles": [
+        "frontalis_outer_L",
+        "frontalis_outer_R"
+      ],
+      "mp478_vertices": [
+        21,
+        46,
+        53,
+        54,
+        63,
+        68,
+        70,
+        71,
+        103,
+        104,
+        139,
+        156,
+        162,
+        251,
+        276,
+        283,
+        284,
+        293,
+        298,
+        300,
+        301,
+        332,
+        333,
+        368,
+        383,
+        389
+      ],
+      "n_vertices": 26
+    },
+    "AU04": {
+      "muscles": [
+        "corrugator_L",
+        "corrugator_R",
+        "procerus"
+      ],
+      "mp478_vertices": [
+        3,
+        6,
+        8,
+        9,
+        55,
+        65,
+        107,
+        122,
+        151,
+        168,
+        174,
+        188,
+        195,
+        196,
+        197,
+        248,
+        285,
+        295,
+        336,
+        351,
+        399,
+        412,
+        419
+      ],
+      "n_vertices": 23
+    },
+    "AU05": {
+      "muscles": [
+        "levator_palpebrae_L",
+        "levator_palpebrae_R"
+      ],
+      "mp478_vertices": [
+        27,
+        28,
+        29,
+        30,
+        56,
+        189,
+        193,
+        221,
+        222,
+        223,
+        224,
+        244,
+        245,
+        257,
+        258,
+        259,
+        260,
+        286,
+        413,
+        417,
+        441,
+        442,
+        443,
+        444,
+        464,
+        465
+      ],
+      "n_vertices": 26
+    },
+    "AU06": {
+      "muscles": [
+        "orb_oculi_orbital_L",
+        "orb_oculi_orbital_R"
+      ],
+      "mp478_vertices": [
+        31,
+        47,
+        50,
+        100,
+        111,
+        117,
+        118,
+        119,
+        120,
+        143,
+        217,
+        228,
+        261,
+        277,
+        280,
+        329,
+        340,
+        346,
+        347,
+        348,
+        349,
+        372,
+        437,
+        448
+      ],
+      "n_vertices": 24
+    },
+    "AU07": {
+      "muscles": [
+        "orb_oculi_palpebral_L",
+        "orb_oculi_palpebral_R"
+      ],
+      "mp478_vertices": [
+        22,
+        23,
+        24,
+        25,
+        26,
+        35,
+        110,
+        112,
+        113,
+        114,
+        121,
+        124,
+        128,
+        130,
+        190,
+        225,
+        226,
+        229,
+        230,
+        231,
+        232,
+        233,
+        243,
+        247,
+        252,
+        253,
+        254,
+        255,
+        256,
+        265,
+        339,
+        341,
+        342,
+        343,
+        350,
+        353,
+        357,
+        359,
+        414,
+        445,
+        446,
+        449,
+        450,
+        451,
+        452,
+        453,
+        463,
+        467
+      ],
+      "n_vertices": 48
+    },
+    "AU09": {
+      "muscles": [
+        "llsan_L",
+        "llsan_R"
+      ],
+      "mp478_vertices": [
+        1,
+        4,
+        5,
+        44,
+        45,
+        48,
+        49,
+        51,
+        59,
+        64,
+        79,
+        102,
+        115,
+        129,
+        131,
+        134,
+        166,
+        198,
+        209,
+        218,
+        219,
+        220,
+        235,
+        236,
+        237,
+        239,
+        274,
+        275,
+        278,
+        279,
+        281,
+        289,
+        294,
+        309,
+        331,
+        344,
+        358,
+        360,
+        363,
+        392,
+        420,
+        429,
+        438,
+        439,
+        440,
+        455,
+        456,
+        457,
+        459
+      ],
+      "n_vertices": 49
+    },
+    "AU10": {
+      "muscles": [
+        "levator_labii_L",
+        "levator_labii_R"
+      ],
+      "mp478_vertices": [
+        36,
+        126,
+        142,
+        266,
+        355,
+        371
+      ],
+      "n_vertices": 6
+    },
+    "AU11": {
+      "muscles": [
+        "zygomaticus_minor_L",
+        "zygomaticus_minor_R"
+      ],
+      "mp478_vertices": [
+        34,
+        93,
+        116,
+        123,
+        127,
+        137,
+        227,
+        234,
+        264,
+        323,
+        345,
+        352,
+        356,
+        366,
+        447,
+        454
+      ],
+      "n_vertices": 16
+    },
+    "AU12": {
+      "muscles": [
+        "zygomaticus_major_L",
+        "zygomaticus_major_R"
+      ],
+      "mp478_vertices": [
+        101,
+        147,
+        187,
+        330,
+        376,
+        411
+      ],
+      "n_vertices": 6
+    },
+    "AU13": {
+      "muscles": [
+        "levator_anguli_oris_L",
+        "levator_anguli_oris_R"
+      ],
+      "mp478_vertices": [
+        203,
+        205,
+        206,
+        423,
+        425,
+        426
+      ],
+      "n_vertices": 6
+    },
+    "AU14": {
+      "muscles": [
+        "buccinator_L",
+        "buccinator_R"
+      ],
+      "mp478_vertices": [
+        32,
+        43,
+        57,
+        106,
+        194,
+        202,
+        204,
+        207,
+        211,
+        212,
+        214,
+        216,
+        262,
+        273,
+        287,
+        335,
+        418,
+        422,
+        424,
+        427,
+        431,
+        432,
+        434,
+        436
+      ],
+      "n_vertices": 24
+    },
+    "AU15": {
+      "muscles": [
+        "depressor_anguli_oris_L",
+        "depressor_anguli_oris_R"
+      ],
+      "mp478_vertices": [
+        61,
+        76,
+        135,
+        169,
+        170,
+        210,
+        291,
+        306,
+        364,
+        394,
+        395,
+        430
+      ],
+      "n_vertices": 12
+    },
+    "AU16": {
+      "muscles": [
+        "depressor_labii_L",
+        "depressor_labii_R"
+      ],
+      "mp478_vertices": [
+        62,
+        77,
+        84,
+        85,
+        86,
+        89,
+        90,
+        91,
+        96,
+        146,
+        179,
+        180,
+        181,
+        182,
+        292,
+        307,
+        314,
+        315,
+        316,
+        319,
+        320,
+        321,
+        325,
+        375,
+        403,
+        404,
+        405,
+        406
+      ],
+      "n_vertices": 28
+    },
+    "AU17": {
+      "muscles": [
+        "mentalis"
+      ],
+      "mp478_vertices": [
+        18,
+        83,
+        140,
+        148,
+        152,
+        171,
+        175,
+        176,
+        199,
+        200,
+        201,
+        208,
+        313,
+        369,
+        377,
+        396,
+        400,
+        421,
+        428
+      ],
+      "n_vertices": 19
+    },
+    "AU20": {
+      "muscles": [
+        "risorius_L",
+        "risorius_R"
+      ],
+      "mp478_vertices": [
+        149,
+        150,
+        378,
+        379
+      ],
+      "n_vertices": 4
+    },
+    "AU24": {
+      "muscles": [
+        "orbicularis_oris"
+      ],
+      "mp478_vertices": [
+        0,
+        2,
+        11,
+        12,
+        15,
+        16,
+        17,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        72,
+        73,
+        74,
+        92,
+        164,
+        165,
+        167,
+        183,
+        184,
+        185,
+        186,
+        267,
+        268,
+        269,
+        270,
+        271,
+        272,
+        302,
+        303,
+        304,
+        322,
+        391,
+        393,
+        407,
+        408,
+        409,
+        410
+      ],
+      "n_vertices": 40
+    },
+    "AU26": {
+      "muscles": [
+        "masseter_L",
+        "masseter_R"
+      ],
+      "mp478_vertices": [
+        58,
+        132,
+        136,
+        138,
+        172,
+        177,
+        192,
+        213,
+        215,
+        288,
+        361,
+        365,
+        367,
+        397,
+        401,
+        416,
+        433,
+        435
+      ],
+      "n_vertices": 18
+    },
+    "AU38": {
+      "muscles": [
+        "nasalis_L",
+        "nasalis_R"
+      ],
+      "mp478_vertices": [
+        19,
+        20,
+        60,
+        75,
+        94,
+        97,
+        98,
+        99,
+        125,
+        141,
+        238,
+        240,
+        241,
+        242,
+        250,
+        290,
+        305,
+        326,
+        327,
+        328,
+        354,
+        370,
+        458,
+        460,
+        461,
+        462
+      ],
+      "n_vertices": 26
+    }
+  }
+}

--- a/feat/resources/blendshape_region_map.json
+++ b/feat/resources/blendshape_region_map.json
@@ -1,0 +1,678 @@
+{
+  "_meta": {
+    "description": "Non-overlapping blendshape region overlay on the MediaPipe-478 mesh. Winner-take-all geodesic-Voronoi partition of the bundled canonical mesh, walled off by the eye/mouth aperture rings.",
+    "kind": "blendshape",
+    "n_regions": 33,
+    "tightness": 0.1,
+    "mesh": "feat/resources/canonical_face_model.pt (468 verts)",
+    "generator": "scripts/build_region_maps.py",
+    "sources": [
+      "FACS (Ekman & Friesen)",
+      "melindaozel.com/arkit-to-facs-cheat-sheet",
+      "pooyadeperson.com ARKit-52 anatomy guide"
+    ]
+  },
+  "regions": {
+    "browInnerUp": {
+      "au": "AU01",
+      "muscle": "frontalis_medial",
+      "side": "C",
+      "mp478_vertices": [
+        10,
+        67,
+        69,
+        108,
+        109,
+        151,
+        297,
+        299,
+        337,
+        338
+      ],
+      "n_vertices": 10
+    },
+    "browOuterUpRight": {
+      "au": "AU02",
+      "muscle": "frontalis_lateral",
+      "side": "R",
+      "mp478_vertices": [
+        21,
+        46,
+        52,
+        53,
+        54,
+        63,
+        68,
+        70,
+        71,
+        103,
+        104,
+        105,
+        139,
+        156,
+        162
+      ],
+      "n_vertices": 15
+    },
+    "browOuterUpLeft": {
+      "au": "AU02",
+      "muscle": "frontalis_lateral",
+      "side": "L",
+      "mp478_vertices": [
+        251,
+        276,
+        282,
+        283,
+        284,
+        293,
+        298,
+        300,
+        301,
+        332,
+        333,
+        334,
+        368,
+        383,
+        389
+      ],
+      "n_vertices": 15
+    },
+    "browDownRight": {
+      "au": "AU04",
+      "muscle": "corrugator+procerus",
+      "side": "R",
+      "mp478_vertices": [
+        55,
+        65,
+        66,
+        107
+      ],
+      "n_vertices": 4
+    },
+    "browDownLeft": {
+      "au": "AU04",
+      "muscle": "corrugator+procerus",
+      "side": "L",
+      "mp478_vertices": [
+        285,
+        295,
+        296,
+        336
+      ],
+      "n_vertices": 4
+    },
+    "eyeWideRight": {
+      "au": "AU05",
+      "muscle": "levator_palpebrae",
+      "side": "R",
+      "mp478_vertices": [
+        122,
+        188,
+        189,
+        193,
+        196,
+        221,
+        222,
+        223,
+        244,
+        245
+      ],
+      "n_vertices": 10
+    },
+    "eyeWideLeft": {
+      "au": "AU05",
+      "muscle": "levator_palpebrae",
+      "side": "L",
+      "mp478_vertices": [
+        351,
+        412,
+        413,
+        417,
+        419,
+        441,
+        442,
+        443,
+        464,
+        465
+      ],
+      "n_vertices": 10
+    },
+    "cheekSquintRight": {
+      "au": "AU06",
+      "muscle": "orb_oculi_orbital",
+      "side": "R",
+      "mp478_vertices": [
+        50,
+        101,
+        111,
+        116,
+        117,
+        118,
+        119,
+        120,
+        123,
+        227
+      ],
+      "n_vertices": 10
+    },
+    "cheekSquintLeft": {
+      "au": "AU06",
+      "muscle": "orb_oculi_orbital",
+      "side": "L",
+      "mp478_vertices": [
+        280,
+        330,
+        340,
+        345,
+        346,
+        347,
+        348,
+        349,
+        352,
+        447
+      ],
+      "n_vertices": 10
+    },
+    "eyeSquintRight": {
+      "au": "AU07",
+      "muscle": "orb_oculi_palpebral",
+      "side": "R",
+      "mp478_vertices": [
+        23,
+        24,
+        25,
+        31,
+        34,
+        35,
+        110,
+        124,
+        143,
+        226,
+        228,
+        229,
+        230
+      ],
+      "n_vertices": 13
+    },
+    "eyeSquintLeft": {
+      "au": "AU07",
+      "muscle": "orb_oculi_palpebral",
+      "side": "L",
+      "mp478_vertices": [
+        253,
+        254,
+        255,
+        261,
+        264,
+        265,
+        339,
+        353,
+        372,
+        446,
+        448,
+        449,
+        450
+      ],
+      "n_vertices": 13
+    },
+    "eyeBlinkRight": {
+      "au": "AU45",
+      "muscle": "orb_oculi_palpebral",
+      "side": "R",
+      "mp478_vertices": [
+        22,
+        26,
+        27,
+        28,
+        29,
+        30,
+        47,
+        56,
+        112,
+        113,
+        114,
+        121,
+        128,
+        130,
+        174,
+        190,
+        224,
+        225,
+        231,
+        232,
+        233,
+        243,
+        247
+      ],
+      "n_vertices": 23
+    },
+    "eyeBlinkLeft": {
+      "au": "AU45",
+      "muscle": "orb_oculi_palpebral",
+      "side": "L",
+      "mp478_vertices": [
+        252,
+        256,
+        257,
+        258,
+        259,
+        260,
+        277,
+        286,
+        341,
+        342,
+        343,
+        350,
+        357,
+        359,
+        399,
+        414,
+        444,
+        445,
+        451,
+        452,
+        453,
+        463,
+        467
+      ],
+      "n_vertices": 23
+    },
+    "noseSneerRight": {
+      "au": "AU09",
+      "muscle": "llsan",
+      "side": "R",
+      "mp478_vertices": [
+        3,
+        20,
+        44,
+        45,
+        48,
+        49,
+        51,
+        59,
+        60,
+        64,
+        75,
+        79,
+        98,
+        102,
+        115,
+        129,
+        131,
+        134,
+        166,
+        198,
+        203,
+        209,
+        218,
+        219,
+        220,
+        235,
+        236,
+        237,
+        238,
+        239,
+        240,
+        241
+      ],
+      "n_vertices": 32
+    },
+    "noseSneerLeft": {
+      "au": "AU09",
+      "muscle": "llsan",
+      "side": "L",
+      "mp478_vertices": [
+        248,
+        250,
+        274,
+        275,
+        278,
+        279,
+        281,
+        289,
+        290,
+        294,
+        305,
+        309,
+        327,
+        331,
+        344,
+        358,
+        360,
+        363,
+        392,
+        420,
+        423,
+        429,
+        438,
+        439,
+        440,
+        455,
+        456,
+        457,
+        458,
+        459,
+        460,
+        461
+      ],
+      "n_vertices": 32
+    },
+    "mouthUpperUpRight": {
+      "au": "AU10",
+      "muscle": "levator_labii",
+      "side": "R",
+      "mp478_vertices": [
+        36,
+        39,
+        41,
+        73,
+        100,
+        126,
+        142,
+        217
+      ],
+      "n_vertices": 8
+    },
+    "mouthUpperUpLeft": {
+      "au": "AU10",
+      "muscle": "levator_labii",
+      "side": "L",
+      "mp478_vertices": [
+        266,
+        269,
+        271,
+        303,
+        329,
+        355,
+        371,
+        437
+      ],
+      "n_vertices": 8
+    },
+    "mouthSmileRight": {
+      "au": "AU12",
+      "muscle": "zygomaticus_major",
+      "side": "R",
+      "mp478_vertices": [
+        147,
+        177,
+        187,
+        192,
+        205,
+        206,
+        207
+      ],
+      "n_vertices": 7
+    },
+    "mouthSmileLeft": {
+      "au": "AU12",
+      "muscle": "zygomaticus_major",
+      "side": "L",
+      "mp478_vertices": [
+        376,
+        401,
+        411,
+        416,
+        425,
+        426,
+        427
+      ],
+      "n_vertices": 7
+    },
+    "mouthDimpleRight": {
+      "au": "AU14",
+      "muscle": "buccinator",
+      "side": "R",
+      "mp478_vertices": [
+        43,
+        106
+      ],
+      "n_vertices": 2
+    },
+    "mouthDimpleLeft": {
+      "au": "AU14",
+      "muscle": "buccinator",
+      "side": "L",
+      "mp478_vertices": [
+        273,
+        335
+      ],
+      "n_vertices": 2
+    },
+    "mouthStretchRight": {
+      "au": "AU20",
+      "muscle": "risorius",
+      "side": "R",
+      "mp478_vertices": [
+        140,
+        149,
+        150,
+        169,
+        170
+      ],
+      "n_vertices": 5
+    },
+    "mouthStretchLeft": {
+      "au": "AU20",
+      "muscle": "risorius",
+      "side": "L",
+      "mp478_vertices": [
+        369,
+        378,
+        379,
+        394,
+        395
+      ],
+      "n_vertices": 5
+    },
+    "mouthFrownRight": {
+      "au": "AU15",
+      "muscle": "depressor_anguli_oris",
+      "side": "R",
+      "mp478_vertices": [
+        32,
+        135,
+        136,
+        138,
+        194,
+        204,
+        210,
+        211
+      ],
+      "n_vertices": 8
+    },
+    "mouthFrownLeft": {
+      "au": "AU15",
+      "muscle": "depressor_anguli_oris",
+      "side": "L",
+      "mp478_vertices": [
+        262,
+        364,
+        365,
+        367,
+        418,
+        424,
+        430,
+        431
+      ],
+      "n_vertices": 8
+    },
+    "mouthLowerDownRight": {
+      "au": "AU16",
+      "muscle": "depressor_labii",
+      "side": "R",
+      "mp478_vertices": [
+        77,
+        84,
+        85,
+        86,
+        96,
+        146,
+        179,
+        180,
+        181,
+        182
+      ],
+      "n_vertices": 10
+    },
+    "mouthLowerDownLeft": {
+      "au": "AU16",
+      "muscle": "depressor_labii",
+      "side": "L",
+      "mp478_vertices": [
+        307,
+        314,
+        315,
+        316,
+        325,
+        375,
+        403,
+        404,
+        405,
+        406
+      ],
+      "n_vertices": 10
+    },
+    "mouthShrugLower": {
+      "au": "AU17",
+      "muscle": "mentalis",
+      "side": "C",
+      "mp478_vertices": [
+        18,
+        83,
+        201,
+        313,
+        421
+      ],
+      "n_vertices": 5
+    },
+    "mouthShrugUpper": {
+      "au": "AU17",
+      "muscle": "mentalis_upper",
+      "side": "C",
+      "mp478_vertices": [
+        2,
+        19,
+        92,
+        94,
+        97,
+        99,
+        125,
+        141,
+        164,
+        165,
+        167,
+        242,
+        322,
+        326,
+        328,
+        354,
+        370,
+        391,
+        393,
+        462
+      ],
+      "n_vertices": 20
+    },
+    "mouthPucker": {
+      "au": "AU18",
+      "muscle": "orbicularis_oris",
+      "side": "C",
+      "mp478_vertices": [
+        0,
+        11,
+        12,
+        15,
+        16,
+        17,
+        37,
+        38,
+        72,
+        267,
+        268,
+        302
+      ],
+      "n_vertices": 12
+    },
+    "mouthFunnel": {
+      "au": "AU22",
+      "muscle": "orbicularis_oris",
+      "side": "C",
+      "mp478_vertices": [
+        40,
+        42,
+        61,
+        62,
+        74,
+        76,
+        89,
+        90,
+        91,
+        183,
+        184,
+        185,
+        270,
+        272,
+        291,
+        292,
+        304,
+        306,
+        319,
+        320,
+        321,
+        407,
+        408,
+        409
+      ],
+      "n_vertices": 24
+    },
+    "cheekPuff": {
+      "au": "AD34",
+      "muscle": "buccinator",
+      "side": "C",
+      "mp478_vertices": [
+        57,
+        186,
+        202,
+        212,
+        214,
+        216,
+        287,
+        410,
+        422,
+        432,
+        434,
+        436
+      ],
+      "n_vertices": 12
+    },
+    "jawOpen": {
+      "au": "AU26",
+      "muscle": "masseter+pterygoid",
+      "side": "C",
+      "mp478_vertices": [
+        58,
+        132,
+        148,
+        152,
+        171,
+        172,
+        175,
+        199,
+        200,
+        208,
+        213,
+        215,
+        288,
+        361,
+        377,
+        396,
+        397,
+        428,
+        433,
+        435
+      ],
+      "n_vertices": 20
+    }
+  }
+}

--- a/feat/tests/test_plot.py
+++ b/feat/tests/test_plot.py
@@ -147,6 +147,19 @@ def test_plot_detections(default_detector, single_face_img, multi_face_img):
     with pytest.raises(NotImplementedError):
         multi_image_mix_prediction.plot_detections(faces="aus")
 
+    # AU region overlay (dense-mesh, coloured by detected AU intensities)
+    figs = single_image_single_face_prediction.plot_detections(
+        faces="au_regions", au_barplot=False, emotion_barplot=False
+    )
+    assert len(figs) == 1
+    plt.close("all")
+    # like faces='aus', region overlays are single-face only
+    with pytest.raises(NotImplementedError):
+        single_image_multi_face_prediction.plot_detections(faces="au_regions")
+    # blendshape overlay needs blendshape detections (Detectorv2 / MPDetector)
+    with pytest.raises(ValueError):
+        single_image_single_face_prediction.plot_detections(faces="blendshape_regions")
+
 
 def test_animate_face():
     # Start with neutral face

--- a/feat/tests/test_region_maps.py
+++ b/feat/tests/test_region_maps.py
@@ -147,7 +147,7 @@ class TestPlot:
         plt.close(ax.figure)
 
     def test_overlay_on_detected_mesh(self):
-        """Passing a deformed 478-mesh in image coords overlays on a host axis."""
+        """Passing a deformed mesh in image coords overlays on a host axis."""
         from feat.plotting import plot_face_regions
 
         V, _ = rm._canonical_geometry()
@@ -157,6 +157,32 @@ class TestPlot:
         out = plot_face_regions(values={"AU12": 1.0}, kind="au", landmarks=mesh, ax=ax)
         assert out is ax
         plt.close(ax.figure)
+
+    def test_overlay_on_478_mesh_matches_468(self):
+        """A real 478-vertex MediaPipe mesh (10 trailing iris verts) must render
+        the same overlay as its 468-vertex face slice — the subdivision topology
+        is 468-based, so the extra iris rows must be trimmed, not shift the
+        midpoint indices (regression for the dense_positions index shift)."""
+        from feat.plotting import plot_face_regions
+        from matplotlib.collections import PolyCollection
+
+        V, _ = rm._canonical_geometry()
+        mesh468 = V[:, :2] * 100 + 200
+        mesh478 = np.vstack([mesh468, mesh468[:10] + 1234.0])  # bogus iris rows
+
+        def polys(mesh):
+            _, ax = plt.subplots()
+            plot_face_regions(values={"AU12": 1.0, "AU06": 0.6}, kind="au",
+                              landmarks=mesh, ax=ax)
+            out = [p for c in ax.collections
+                   if isinstance(c, PolyCollection) for p in c.get_paths()]
+            plt.close(ax.figure)
+            return out
+
+        p468, p478 = polys(mesh468), polys(mesh478)
+        assert len(p468) == len(p478) and len(p468) > 0
+        for a, b in zip(p468, p478):
+            assert np.allclose(a.vertices, b.vertices)
 
     def test_bad_inputs(self, au_map):
         from feat.plotting import plot_face_regions

--- a/feat/tests/test_region_maps.py
+++ b/feat/tests/test_region_maps.py
@@ -1,0 +1,167 @@
+"""Tests for ``feat.utils.region_maps`` + ``feat.plotting.plot_face_regions`` —
+the non-overlapping AU / ARKit-blendshape region overlays on the MP-478 mesh
+shipped at ``feat/resources/{au,blendshape}_region_map.json``.
+
+Validates structural invariants (vertex range, aperture exclusion, AU
+non-overlap, L/R mirror symmetry), that both maps regenerate byte-identically
+from their seed tables (so the shipped files can't drift from source), and that
+the plotting API renders map + activation views without error.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from feat.utils import region_maps as rm
+
+
+@pytest.fixture(scope="module")
+def au_map():
+    return rm.load_au_region_map()
+
+
+@pytest.fixture(scope="module")
+def bs_map():
+    return rm.load_blendshape_region_map()
+
+
+@pytest.fixture(scope="module")
+def canonical():
+    V, _ = rm._canonical_geometry()
+    return V
+
+
+class TestLoad:
+    def test_returns_independent_copies(self):
+        a = rm.load_au_region_map()
+        b = rm.load_au_region_map()
+        assert a == b and a is not b
+        a["AU12"]["mp478_vertices"].append(99999)
+        assert 99999 not in rm.load_au_region_map()["AU12"]["mp478_vertices"]
+
+    def test_au_schema(self, au_map):
+        for au, spec in au_map.items():
+            assert au.startswith("AU")
+            assert spec["mp478_vertices"] == sorted(set(spec["mp478_vertices"]))
+            assert spec["n_vertices"] == len(spec["mp478_vertices"]) > 0
+            assert spec["muscles"] and all(isinstance(m, str) for m in spec["muscles"])
+
+    def test_blendshape_schema(self, bs_map):
+        for bs, spec in bs_map.items():
+            assert spec["au"].startswith(("AU", "AD"))
+            assert spec["side"] in ("L", "R", "C")
+            assert spec["n_vertices"] == len(spec["mp478_vertices"]) > 0
+
+
+class TestInvariants:
+    def test_vertices_in_canonical_range(self, au_map, bs_map):
+        for m in (au_map, bs_map):
+            for spec in m.values():
+                assert all(0 <= v < 468 for v in spec["mp478_vertices"])
+
+    def test_no_aperture_leak(self, au_map, bs_map):
+        for name, m in (("au", au_map), ("bs", bs_map)):
+            for region, spec in m.items():
+                leak = set(spec["mp478_vertices"]) & rm.APERTURE
+                assert not leak, f"{name}:{region} covers aperture {sorted(leak)}"
+
+    @pytest.mark.parametrize("which", ["au", "bs"])
+    def test_regions_are_non_overlapping(self, which, au_map, bs_map):
+        """Both maps are strict partitions — each vertex in at most one region.
+        (Blendshape L/R divide exactly at the midline, so no shared seam.)"""
+        m = au_map if which == "au" else bs_map
+        seen: dict[int, str] = {}
+        for region, spec in m.items():
+            for v in spec["mp478_vertices"]:
+                assert v not in seen, f"{which}: vertex {v} in {seen.get(v)} & {region}"
+                seen[v] = region
+
+    def test_blendshape_left_right_mirror(self, bs_map, canonical):
+        """``...Left`` and ``...Right`` regions are exact mirrors across the
+        midline — the partition is symmetrized (``_symmetrize_partition``), so
+        winner-take-all boundary noise can't make paired regions asymmetric."""
+        for name, spec in bs_map.items():
+            if not name.endswith("Left"):
+                continue
+            right = name[:-4] + "Right"
+            assert right in bs_map, f"missing {right}"
+            assert spec["n_vertices"] == bs_map[right]["n_vertices"]
+            cl = canonical[spec["mp478_vertices"]].mean(0)
+            cr = canonical[bs_map[right]["mp478_vertices"]].mean(0)
+            assert abs(cl[0] + cr[0]) < 0.05, f"{name}: not mirrored in x"
+            assert abs(cl[1] - cr[1]) < 0.05, f"{name}: height mismatch"
+
+
+class TestRegenerationMatchesShipped:
+    def test_au_map_regenerates(self, au_map):
+        assert rm.build_au_region_map() == au_map
+
+    def test_blendshape_map_regenerates(self, bs_map):
+        assert rm.build_blendshape_region_map() == bs_map
+
+
+class TestRenderAssets:
+    def test_au_assets_disjoint(self):
+        a = rm.render_assets("au")
+        assert {"parents", "tris", "region_verts", "n_base"} <= a.keys()
+        seen: set[int] = set()
+        for verts in a["region_verts"].values():
+            assert not (verts & seen)
+            seen |= verts
+
+    def test_dense_positions_match_subdivision(self):
+        """``dense_positions`` on the canonical base reproduces the subdivided
+        canonical vertices the assets were built from."""
+        a = rm.render_assets("au")
+        V, _ = rm._canonical_geometry()
+        dense = rm.dense_positions(rm.project_xy(V), a["parents"])
+        assert len(dense) == a["n_base"] + len(a["parents"])
+
+    def test_bad_kind_raises(self):
+        with pytest.raises(ValueError):
+            rm.render_assets("nope")
+
+
+class TestPlot:
+    def test_map_views(self):
+        from feat.plotting import plot_face_regions
+
+        for kind in ("au", "blendshape"):
+            ax = plot_face_regions(kind=kind)
+            assert ax.collections  # something was drawn
+            plt.close(ax.figure)
+
+    def test_activation_view_dict_and_array(self, au_map):
+        from feat.plotting import plot_face_regions
+
+        ax = plot_face_regions(values={"AU12": 1.0, "AU06": 0.5}, kind="au")
+        plt.close(ax.figure)
+        arr = np.zeros(len(au_map))
+        arr[0] = 1.0
+        ax = plot_face_regions(values=arr, kind="au")
+        plt.close(ax.figure)
+
+    def test_overlay_on_detected_mesh(self):
+        """Passing a deformed 478-mesh in image coords overlays on a host axis."""
+        from feat.plotting import plot_face_regions
+
+        V, _ = rm._canonical_geometry()
+        mesh = V[:, :2] * 100 + 200  # fake image-coord landmarks
+        _, ax = plt.subplots()
+        ax.imshow(np.zeros((400, 400, 3), dtype=np.uint8))
+        out = plot_face_regions(values={"AU12": 1.0}, kind="au", landmarks=mesh, ax=ax)
+        assert out is ax
+        plt.close(ax.figure)
+
+    def test_bad_inputs(self, au_map):
+        from feat.plotting import plot_face_regions
+
+        with pytest.raises(ValueError):
+            plot_face_regions(kind="nope")
+        with pytest.raises(ValueError):
+            plot_face_regions(values=np.zeros(len(au_map) + 3), kind="au")

--- a/feat/utils/region_maps.py
+++ b/feat/utils/region_maps.py
@@ -1,0 +1,489 @@
+"""Facial AU / ARKit-blendshape region overlays on the MediaPipe-478 mesh.
+
+This is the dense-mesh, *non-overlapping* successor to the dlib-68 muscle
+polygons in ``feat.plotting.draw_muscles`` and the overlapping muscle map in
+``feat.utils.muscle_to_landmark``. It ships two maps:
+
+* ``au_region_map.json``        — the 20 FACS AUs, left+right merged per AU.
+* ``blendshape_region_map.json`` — the spatially-distinct ARKit blendshapes,
+  Left/Right kept independent (ARKit pre-splits ``...Left``/``...Right``).
+
+Both are built by a **winner-take-all geodesic-Voronoi partition** of the mesh:
+each vertex is assigned to the single nearest region seed by walking the mesh
+surface (Dijkstra over the triangle-edge graph, capped at ``TIGHTNESS`` of the
+face span), with the eye/mouth aperture rings walling growth off. The partition
+is non-overlapping *by construction*, which fixes the heavy region overlap of
+the geodesic-grow muscle map (where 323/394 covered verts sat in >=2 muscles).
+
+The AU <-> muscle <-> blendshape correspondence is grounded in:
+* FACS (Ekman & Friesen) — AU -> muscle.
+* Melinda Ozel's ARKit-to-FACS cheat sheet (melindaozel.com/arkit-to-facs-cheat-sheet).
+* pooyadeperson's "Ultimate Guide to ARKit's 52 Facial Blendshapes" (anatomy refs).
+
+Rendering smooths the coarse 468-vertex mesh by midpoint-subdividing it
+``SUBDIV_LEVELS`` times before filling triangles. The subdivision topology and
+the dense per-vertex region labels are fixed in index space, so the same assets
+overlay a live detected 478-mesh — only the dense vertex *positions* are
+recomputed per frame (``dense_positions``). See ``feat.plotting.plot_face_regions``.
+"""
+
+from __future__ import annotations
+
+import copy
+import heapq
+import json
+import os
+from collections import defaultdict
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+from feat.utils.io import get_resource_path
+from feat.utils.mp_plotting import FaceLandmarksConnections as _F
+
+# --- partition / render tuning (the user-approved look) ---
+TIGHTNESS = 0.10      # max geodesic reach of a seed, as a fraction of face span
+SUBDIV_LEVELS = 2     # midpoint subdivisions applied before rendering (smoothing)
+
+AU_MAP_FILENAME = "au_region_map.json"
+BLENDSHAPE_MAP_FILENAME = "blendshape_region_map.json"
+
+
+# ---------------------------------------------------------------------------
+# Aperture rings — the eye/mouth *openings*. Growth never enters these and no
+# region may cover them (orbicularis oculi/oris are annuli around the holes).
+# Eye rings come from MediaPipe's own canonical groups; the inner-lip ring has
+# no dedicated group (FACE_LANDMARKS_LIPS bundles inner+outer) so it's explicit.
+# ---------------------------------------------------------------------------
+def _group_verts(name: str) -> set[int]:
+    return {v for c in getattr(_F, name) for v in (c.start, c.end)}
+
+
+_INNER_LIP = {78, 191, 80, 81, 82, 13, 312, 311, 310, 415, 308,
+              95, 88, 178, 87, 14, 317, 402, 318, 324}
+APERTURE = (_group_verts("FACE_LANDMARKS_RIGHT_EYE")
+            | _group_verts("FACE_LANDMARKS_LEFT_EYE")
+            | _INNER_LIP)
+
+_OUTER_LIP = [61, 185, 40, 39, 37, 0, 267, 269, 270, 409, 291,
+              146, 91, 181, 84, 17, 314, 405, 321, 375]
+
+
+# ---------------------------------------------------------------------------
+# Seed tables — anatomical SKIN-insertion vertices per region (MP-478 indices).
+# A region = its seeds grown over the surface to the Voronoi boundary.
+# ---------------------------------------------------------------------------
+# muscle -> (AU, [seed verts]). Sides: _L = subject-left (263/291/336 family),
+# _R = subject-right (33/61/107 family). Mirrors map_muscles_canonical_geodesic.
+MUSCLE_SEEDS: dict[str, tuple[str, list[int]]] = {
+    "frontalis_inner_R": ("AU01", [107, 66, 105, 69]),
+    "frontalis_inner_L": ("AU01", [336, 296, 334, 299]),
+    "frontalis_outer_R": ("AU02", [105, 63, 70, 71, 54, 68]),
+    "frontalis_outer_L": ("AU02", [334, 293, 300, 301, 284, 298]),
+    "corrugator_R": ("AU04", [107, 55, 65, 9]),
+    "corrugator_L": ("AU04", [336, 285, 295, 8]),
+    "procerus": ("AU04", [8, 9, 168, 6]),
+    "levator_palpebrae_R": ("AU05", [223, 222, 221, 189, 56]),
+    "levator_palpebrae_L": ("AU05", [443, 442, 441, 413, 286]),
+    "orb_oculi_orbital_R": ("AU06", [117, 118, 119, 100, 50, 36, 111, 31]),
+    "orb_oculi_orbital_L": ("AU06", [346, 347, 348, 329, 280, 266, 340, 261]),
+    "orb_oculi_palpebral_R": ("AU07", [226, 110, 24, 23, 22, 26, 112, 190]),
+    "orb_oculi_palpebral_L": ("AU07", [446, 339, 254, 253, 252, 256, 341, 414]),
+    "llsan_R": ("AU09", [115, 48, 49, 64, 102, 219]),
+    "llsan_L": ("AU09", [344, 278, 279, 294, 331, 439]),
+    "levator_labii_R": ("AU10", [205, 36, 142, 203, 206, 207]),
+    "levator_labii_L": ("AU10", [425, 266, 371, 423, 426, 427]),
+    "zygomaticus_minor_R": ("AU11", [116, 123, 117, 50]),
+    "zygomaticus_minor_L": ("AU11", [345, 352, 346, 280]),
+    "zygomaticus_major_R": ("AU12", [50, 101, 205, 187, 207, 61]),
+    "zygomaticus_major_L": ("AU12", [280, 330, 425, 411, 427, 291]),
+    "levator_anguli_oris_R": ("AU13", [205, 203, 206, 61]),
+    "levator_anguli_oris_L": ("AU13", [425, 423, 426, 291]),
+    "buccinator_R": ("AU14", [212, 202, 57, 43, 204, 207]),
+    "buccinator_L": ("AU14", [432, 422, 287, 273, 424, 427]),
+    "depressor_anguli_oris_R": ("AU15", [43, 204, 210, 135, 169, 61]),
+    "depressor_anguli_oris_L": ("AU15", [273, 424, 430, 364, 394, 291]),
+    "depressor_labii_R": ("AU16", [84, 181, 91, 146, 61, 77]),
+    "depressor_labii_L": ("AU16", [314, 405, 321, 375, 291, 307]),
+    "mentalis": ("AU17", [175, 199, 200, 18, 83, 313, 152, 148, 377]),
+    "risorius_R": ("AU20", [212, 202, 210, 169, 150]),
+    "risorius_L": ("AU20", [432, 422, 430, 394, 379]),
+    "orbicularis_oris": ("AU24", list(_OUTER_LIP)),
+    "masseter_R": ("AU26", [58, 172, 136, 132, 215, 138]),
+    "masseter_L": ("AU26", [288, 397, 365, 361, 435, 367]),
+    "nasalis_R": ("AU38", [48, 49, 64, 98, 240]),
+    "nasalis_L": ("AU38", [278, 279, 294, 327, 460]),
+}
+
+# ARKit blendshape -> (AU, muscle, side, [seed verts]). Side in {"L","R","C"}
+# (ARKit Left/Right = subject's left/right). The 8 eyeLook* (gaze) and tongueOut
+# have no facial-skin footprint and are intentionally absent. The pure
+# lip-closure modes (mouthPress/Close/Roll*) deform the same orbicularis-oris
+# skin as Pucker/Funnel/ShrugUpper, so they can't be a distinct cell in a
+# non-overlapping partition and are folded into those lip regions.
+BLENDSHAPE_SEEDS: dict[str, tuple[str, str, str, list[int]]] = {
+    # seeded on the frontalis (medial forehead, ABOVE the corrugator/browDown
+    # band) so the partition can separate inner-brow RAISE from browDown's LOWER.
+    "browInnerUp": ("AU01", "frontalis_medial", "C", [151, 108, 337, 67, 297, 109, 338, 10]),
+    "browOuterUpRight": ("AU02", "frontalis_lateral", "R", [105, 63, 70, 71, 54]),
+    "browOuterUpLeft": ("AU02", "frontalis_lateral", "L", [334, 293, 300, 301, 284]),
+    "browDownRight": ("AU04", "corrugator+procerus", "R", [107, 55, 65, 9, 66]),
+    "browDownLeft": ("AU04", "corrugator+procerus", "L", [336, 285, 295, 8, 296]),
+    "eyeWideRight": ("AU05", "levator_palpebrae", "R", [223, 222, 221, 189]),
+    "eyeWideLeft": ("AU05", "levator_palpebrae", "L", [443, 442, 441, 413]),
+    "cheekSquintRight": ("AU06", "orb_oculi_orbital", "R", [117, 118, 50, 101, 119]),
+    "cheekSquintLeft": ("AU06", "orb_oculi_orbital", "L", [346, 347, 280, 330, 348]),
+    "eyeSquintRight": ("AU07", "orb_oculi_palpebral", "R", [226, 110, 24, 23, 22, 112]),
+    "eyeSquintLeft": ("AU07", "orb_oculi_palpebral", "L", [446, 339, 254, 253, 252, 341]),
+    # lid SKIN just outside the eye ring (ring verts are aperture-blocked)
+    "eyeBlinkRight": ("AU45", "orb_oculi_palpebral", "R", [247, 30, 29, 27, 28, 56, 112, 26, 22]),
+    "eyeBlinkLeft": ("AU45", "orb_oculi_palpebral", "L", [467, 260, 259, 257, 258, 286, 341, 256, 252]),
+    "noseSneerRight": ("AU09", "llsan", "R", [48, 115, 49, 64, 220]),
+    "noseSneerLeft": ("AU09", "llsan", "L", [278, 344, 279, 294, 440]),
+    "mouthUpperUpRight": ("AU10", "levator_labii", "R", [205, 36, 40, 39, 142]),
+    "mouthUpperUpLeft": ("AU10", "levator_labii", "L", [425, 266, 270, 269, 371]),
+    "mouthSmileRight": ("AU12", "zygomaticus_major", "R", [50, 101, 205, 61, 187]),
+    "mouthSmileLeft": ("AU12", "zygomaticus_major", "L", [280, 330, 425, 291, 411]),
+    "mouthDimpleRight": ("AU14", "buccinator", "R", [212, 57, 43, 202]),
+    "mouthDimpleLeft": ("AU14", "buccinator", "L", [432, 287, 273, 422]),
+    "mouthStretchRight": ("AU20", "risorius", "R", [212, 202, 210, 169]),
+    "mouthStretchLeft": ("AU20", "risorius", "L", [432, 422, 430, 394]),
+    "mouthFrownRight": ("AU15", "depressor_anguli_oris", "R", [43, 204, 210, 135]),
+    "mouthFrownLeft": ("AU15", "depressor_anguli_oris", "L", [273, 424, 430, 364]),
+    "mouthLowerDownRight": ("AU16", "depressor_labii", "R", [84, 181, 91, 146]),
+    "mouthLowerDownLeft": ("AU16", "depressor_labii", "L", [314, 405, 321, 375]),
+    "mouthShrugLower": ("AU17", "mentalis", "C", [175, 199, 200, 18, 83, 313]),
+    "mouthShrugUpper": ("AU17", "mentalis_upper", "C", [164, 165, 391, 167, 393]),
+    # NB: mouthPressLeft/Right (AU24) and other pure lip-closure modes
+    # (mouthClose/Roll*) deform the SAME orbicularis-oris/lip skin as Pucker/
+    # Funnel/ShrugUpper and so can't be a distinct cell in a non-overlapping
+    # partition — they're represented by those lip regions.
+    "mouthPucker": ("AU18", "orbicularis_oris", "C", [0, 17, 37, 267, 84, 314]),
+    "mouthFunnel": ("AU22", "orbicularis_oris", "C", [61, 291, 40, 270, 91, 321]),
+    "cheekPuff": ("AD34", "buccinator", "C", [212, 432, 202, 422, 57, 287]),
+    "jawOpen": ("AU26", "masseter+pterygoid", "C", [152, 175, 199, 58, 288, 200]),
+}
+
+
+# ---------------------------------------------------------------------------
+# geometry
+# ---------------------------------------------------------------------------
+def _canonical_geometry():
+    """(V[N,3] float64, tris[M,3] int) — bundled MediaPipe canonical mesh +
+    its full triangulation. Natively upright (no frontalization)."""
+    from feat.utils.face_pose import load_canonical_face_model
+
+    V = load_canonical_face_model().detach().cpu().numpy().astype(np.float64)
+    tess_path = os.path.join(get_resource_path(), "canonical_face_tessellation.json")
+    with open(tess_path) as f:
+        tris = np.array(json.load(f)["triangles"], dtype=int)
+    return V, tris
+
+
+def project_xy(V: np.ndarray) -> np.ndarray:
+    """Frontal x/y projection, flipped so the forehead (v10) is above the chin
+    (v152). ``V`` may be the canonical mesh or a detected mesh (N>=153, x/y in
+    cols 0/1). Used both for geodesic distances and for plotting."""
+    xy = np.asarray(V, dtype=np.float64)[:, :2].copy()
+    if xy[10, 1] < xy[152, 1]:
+        xy[:, 1] = -xy[:, 1]
+    return xy
+
+
+def build_adjacency(tris: np.ndarray, n: int) -> dict[int, list[int]]:
+    adj: dict[int, set] = defaultdict(set)
+    for a, b, c in tris:
+        for u, w in ((a, b), (b, c), (a, c)):
+            adj[int(u)].add(int(w))
+            adj[int(w)].add(int(u))
+    return {k: sorted(v) for k, v in adj.items()}
+
+
+def geodesic_voronoi(seeds_by_region, adj, xy, aperture, max_geo):
+    """Winner-take-all surface partition: assign each vertex to the nearest
+    seed's region by Dijkstra over the edge graph (euclidean edge weights on
+    ``xy``), capped at ``max_geo``, never crossing ``aperture`` verts.
+
+    Returns ``{vertex_index: region_name}``. Non-overlapping by construction —
+    a vertex is claimed once, by whichever region reaches it first/closest."""
+    label: dict[int, str] = {}
+    dist: dict[int, float] = {}
+    pq: list = []
+    for region, seeds in seeds_by_region.items():
+        for s in seeds:
+            if s in aperture or s >= len(xy):
+                continue
+            heapq.heappush(pq, (0.0, int(s), region))
+    while pq:
+        d, v, region = heapq.heappop(pq)
+        if v in label and dist.get(v, np.inf) <= d:
+            continue
+        label[v] = region
+        dist[v] = d
+        for w in adj.get(v, []):
+            if w in aperture:
+                continue
+            nd = d + float(np.linalg.norm(xy[v] - xy[w]))
+            if nd <= max_geo and (w not in dist or nd < dist[w]):
+                dist[w] = nd
+                heapq.heappush(pq, (nd, w, region))
+    return label
+
+
+# vertices on the facial midline (define the mirror axis; stay put when mirrored)
+_MIDLINE_SEEDS = [1, 168, 9, 8, 0, 17, 152, 10, 151, 175, 199, 200, 164, 18, 6, 4]
+
+
+def _mirror_name(name):
+    for a, b in (("Right", "Left"), ("Left", "Right"), ("_R", "_L"), ("_L", "_R")):
+        if name.endswith(a):
+            return name[: -len(a)] + b
+    return name  # center / unsided
+
+
+def _mirror_map(V):
+    """``({v: mirror_v}, midline_set, axis_x)`` — each vertex paired with its
+    nearest neighbour under reflection across the facial midline."""
+    idx = [i for i in _MIDLINE_SEEDS if i < len(V)]
+    axis = float(V[idx, 0].mean())
+    refl = V.copy()
+    refl[:, 0] = 2 * axis - refl[:, 0]
+    M = cKDTree(V).query(refl)[1]
+    span = float(V[:, 0].max() - V[:, 0].min())
+    midline = {int(v) for v in range(len(V))
+               if int(M[v]) == v or abs(V[v, 0] - axis) < 0.02 * span}
+    return {int(v): int(M[v]) for v in range(len(V))}, midline, axis
+
+
+def _symmetrize_partition(label, V):
+    """Force exact L/R mirror symmetry on a partition: keep the subject-right
+    half's assignment and mirror it onto the left (``Left``↔``Right`` swapped),
+    so winner-take-all boundary noise can't make paired regions asymmetric.
+    Center (unsided) regions are mirrored about the midline too.
+
+    Returns ``{vertex: {region, ...}}``. Almost every vertex maps to a single
+    region; a midline-seam vertex on a SIDED region is shared by both mirror
+    partners (e.g. the nose-bridge column joins noseSneerLeft+Right) so the two
+    halves stay contiguous instead of leaving an unassigned gap. ``label``/``V``
+    use final region names + the same vertex set."""
+    V = np.asarray(V, dtype=np.float64)
+    M, midline, axis = _mirror_map(V)
+    # primary half = the side a known subject-right seed (v107) sits on
+    primary_neg = bool((V[107, 0] - axis) < 0) if len(V) > 107 else True
+    out: dict[int, set] = defaultdict(set)
+    for v, name in label.items():
+        if v in midline:
+            # center region keeps the seam vertex; a sided region shares it with
+            # its mirror partner so L/R meet at the midline (no gap).
+            out[v].add(name)
+            out[v].add(_mirror_name(name))
+        elif bool((V[v, 0] - axis) < 0) == primary_neg:
+            out[v].add(name)
+            out[M[v]].add(_mirror_name(name))
+    return out
+
+
+def subdivide(V, tris, aperture, levels):
+    """``levels`` rounds of 1-to-4 midpoint subdivision. Original vertices keep
+    their indices (so seeds and stored vertex ids stay valid). Returns
+    ``(V_dense, tris_dense, aperture_dense, parents)`` where ``parents`` lists,
+    in creation order, the ``(a, b)`` parent pair of each appended midpoint — so
+    a deformed mesh's dense positions can be rebuilt with ``dense_positions``.
+    A midpoint inherits aperture status only if BOTH parents are aperture."""
+    V = [np.asarray(p, dtype=np.float64) for p in V]
+    ap = set(aperture)
+    parents: list[tuple[int, int]] = []
+    for _ in range(levels):
+        cache: dict[tuple[int, int], int] = {}
+        new_tris = []
+
+        def mid(a, b):
+            k = (a, b) if a < b else (b, a)
+            idx = cache.get(k)
+            if idx is None:
+                idx = len(V)
+                cache[k] = idx
+                V.append((V[a] + V[b]) / 2.0)
+                parents.append((a, b))
+                if a in ap and b in ap:
+                    ap.add(idx)
+            return idx
+
+        for a, b, c in tris:
+            a, b, c = int(a), int(b), int(c)
+            ab, bc, ca = mid(a, b), mid(b, c), mid(c, a)
+            new_tris += [(a, ab, ca), (ab, b, bc), (ca, bc, c), (ab, bc, ca)]
+        tris = np.array(new_tris, dtype=int)
+    return np.array(V), tris, ap, parents
+
+
+def dense_positions(V, parents):
+    """Rebuild subdivided vertex positions for an arbitrary base mesh ``V``
+    (e.g. a detected 478-mesh) given the ``parents`` list from ``subdivide``.
+    ``V`` supplies the original vertices; midpoints are filled by averaging."""
+    pos = [np.asarray(p, dtype=np.float64) for p in V]
+    for a, b in parents:
+        pos.append((pos[a] + pos[b]) / 2.0)
+    return np.array(pos)
+
+
+# ---------------------------------------------------------------------------
+# map construction (used by scripts/build_region_maps.py + the loaders' fallback)
+# ---------------------------------------------------------------------------
+def _build_partition_labels(seeds_by_region, V=None, tris=None):
+    """Run the geodesic-Voronoi partition on the (original) canonical mesh.
+    Returns ``(label, V, tris)``."""
+    if V is None or tris is None:
+        V, tris = _canonical_geometry()
+    xy = project_xy(V)
+    adj = build_adjacency(tris, len(V))
+    face = float(np.linalg.norm(xy.max(0) - xy.min(0)))
+    aperture = {a for a in APERTURE if a < len(V)}
+    label = geodesic_voronoi(seeds_by_region, adj, xy, aperture, face * TIGHTNESS)
+    label = _symmetrize_partition(label, V)
+    return label, V, tris
+
+
+def build_au_region_map():
+    """``{AU: {muscles, mp478_vertices, n_vertices}}`` — muscle partition merged
+    to AU (left+right share an AU)."""
+    seeds = {m: s for m, (au, s) in MUSCLE_SEEDS.items()}
+    label, _, _ = _build_partition_labels(seeds)
+    muscle_au = {m: au for m, (au, s) in MUSCLE_SEEDS.items()}
+    by_au: dict[str, set] = defaultdict(set)
+    muscles_by_au: dict[str, set] = defaultdict(set)
+    for v, muscles in label.items():
+        for muscle in muscles:
+            by_au[muscle_au[muscle]].add(v)
+            muscles_by_au[muscle_au[muscle]].add(muscle)
+    out = {}
+    for au in sorted(by_au):
+        verts = sorted(by_au[au])
+        out[au] = dict(muscles=sorted(muscles_by_au[au]),
+                       mp478_vertices=verts, n_vertices=len(verts))
+    return out
+
+
+def _feature_of(blendshape: str) -> str:
+    """``noseSneerLeft`` -> ``noseSneer``; center shapes unchanged. The L/R
+    pair share one symmetric mesh FEATURE, split by the midline at the end."""
+    for suf in ("Left", "Right"):
+        if blendshape.endswith(suf):
+            return blendshape[: -len(suf)]
+    return blendshape
+
+
+def _feature_seeds() -> dict:
+    feat: dict[str, list] = defaultdict(list)
+    for bs, (au, muscle, side, s) in BLENDSHAPE_SEEDS.items():
+        feat[_feature_of(bs)].extend(s)
+    return dict(feat)
+
+
+def build_blendshape_region_map():
+    """``{blendshape: {au, muscle, side, mp478_vertices, n_vertices}}``.
+
+    L/R pairs share one symmetric mesh FEATURE (their seeds merged) grown by the
+    geodesic-Voronoi partition; each sided blendshape is then the half of that
+    feature on its side of the facial midline (center shapes keep the whole,
+    bilateral feature). So L/R divide cleanly down the middle — no winner-take-
+    all asymmetry, no shared midline seam. Non-overlapping by construction."""
+    label, V, _ = _build_partition_labels(_feature_seeds())
+    feat_verts: dict[str, set] = defaultdict(set)
+    for v, names in label.items():
+        for f in names:
+            feat_verts[f].add(v)
+    _, _, axis = _mirror_map(np.asarray(V, dtype=np.float64))
+    eps = 0.01 * float(V[:, 0].max() - V[:, 0].min())
+    out = {}
+    for bs, (au, muscle, side, _seeds) in BLENDSHAPE_SEEDS.items():
+        fv = feat_verts[_feature_of(bs)]
+        if side == "L":          # subject-left half (x > midline)
+            verts = sorted(v for v in fv if V[v, 0] > axis + eps)
+        elif side == "R":        # subject-right half (x < midline)
+            verts = sorted(v for v in fv if V[v, 0] < axis - eps)
+        else:                    # center: whole bilateral feature
+            verts = sorted(fv)
+        out[bs] = dict(au=au, muscle=muscle, side=side,
+                       mp478_vertices=verts, n_vertices=len(verts))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# loaders
+# ---------------------------------------------------------------------------
+_CACHE: dict[str, dict] = {}
+
+
+def _load(filename: str) -> dict:
+    if filename not in _CACHE:
+        path = os.path.join(get_resource_path(), filename)
+        with open(path) as f:
+            _CACHE[filename] = json.load(f)["regions"]
+    return copy.deepcopy(_CACHE[filename])
+
+
+def load_au_region_map() -> dict:
+    """Bundled non-overlapping AU region map (20 AUs, L+R merged). Each value:
+    ``{"muscles": [...], "mp478_vertices": [...], "n_vertices": int}``."""
+    return _load(AU_MAP_FILENAME)
+
+
+def load_blendshape_region_map() -> dict:
+    """Bundled non-overlapping blendshape region map (L/R independent). Each
+    value: ``{"au", "muscle", "side", "mp478_vertices", "n_vertices"}``."""
+    return _load(BLENDSHAPE_MAP_FILENAME)
+
+
+# ---------------------------------------------------------------------------
+# render assets — subdivided topology + dense per-vertex labels, computed once
+# on the canonical mesh and cached. Reused for any 478-mesh (canonical or live).
+# ---------------------------------------------------------------------------
+_RENDER_ASSETS: dict[str, dict] = {}
+
+
+def render_assets(kind: str = "au") -> dict:
+    """Cached rendering assets for ``kind`` in {"au", "blendshape"}:
+
+    ``{"parents": [(a,b)...], "tris": dense_tris[K,3],
+       "region_verts": {region: set(dense vert ids)}, "axis": float, "n_base": 468}``
+
+    Regions are resolved on the SUBDIVIDED canonical mesh (smooth boundaries),
+    keyed by AU for ``"au"`` and by FEATURE (L/R merged) for ``"blendshape"`` —
+    the renderer splits a feature into Left/Right by the midline ``axis`` using
+    triangle centroids. ``parents``/``tris``/``region_verts`` are fixed in index
+    space, so a deformed 478-mesh just needs ``dense_positions(mesh, parents)``.
+    """
+    if kind not in _RENDER_ASSETS:
+        if kind not in ("au", "blendshape"):
+            raise ValueError(f"kind must be 'au' or 'blendshape', got {kind!r}")
+
+        V, tris = _canonical_geometry()
+        n_base = len(V)
+        aperture = {a for a in APERTURE if a < n_base}
+        Vd, tris_d, ap_d, parents = subdivide(V, tris, aperture, SUBDIV_LEVELS)
+        xy = project_xy(Vd)
+        adj = build_adjacency(tris_d, len(Vd))
+        face = float(np.linalg.norm(xy.max(0) - xy.min(0)))
+        max_geo = face * TIGHTNESS
+
+        if kind == "au":
+            seeds = {m: s for m, (au, s) in MUSCLE_SEEDS.items()}
+            muscle_au = {m: au for m, (au, s) in MUSCLE_SEEDS.items()}
+            raw = geodesic_voronoi(seeds, adj, xy, ap_d, max_geo)
+            label = {v: muscle_au[m] for v, m in raw.items()}
+        else:
+            label = geodesic_voronoi(_feature_seeds(), adj, xy, ap_d, max_geo)
+        label = _symmetrize_partition(label, Vd)
+        region_verts: dict[str, set] = defaultdict(set)
+        for v, names in label.items():
+            for name in names:
+                region_verts[name].add(v)
+
+        _RENDER_ASSETS[kind] = dict(parents=parents, tris=tris_d,
+                                    region_verts=dict(region_verts),
+                                    axis=float(_mirror_map(Vd)[2]), n_base=n_base)
+    a = _RENDER_ASSETS[kind]
+    return dict(parents=list(a["parents"]), tris=a["tris"],
+                region_verts={k: set(v) for k, v in a["region_verts"].items()},
+                axis=a["axis"], n_base=a["n_base"])

--- a/scripts/build_region_maps.py
+++ b/scripts/build_region_maps.py
@@ -1,0 +1,70 @@
+"""Generate py-feat's AU + ARKit-blendshape region-overlay maps.
+
+Writes two non-overlapping region maps (geodesic-Voronoi partition of the
+bundled MediaPipe canonical mesh) consumed by ``feat.utils.region_maps`` and
+``feat.plotting.plot_face_regions``:
+
+    feat/resources/au_region_map.json          # 20 AUs, left+right merged
+    feat/resources/blendshape_region_map.json  # ARKit blendshapes, L/R independent
+
+All anatomy (seed verts, AU<->muscle<->blendshape correspondence) lives in
+``feat.utils.region_maps`` so this script, the renderer, and the tests share one
+source of truth. The mapping is grounded in FACS (Ekman & Friesen), Melinda
+Ozel's ARKit-to-FACS cheat sheet, and pooyadeperson's ARKit-52 anatomy guide.
+
+    python scripts/build_region_maps.py
+"""
+import argparse
+import json
+import os
+
+from feat.utils import region_maps as rm
+from feat.utils.io import get_resource_path
+
+
+def _meta(kind, n):
+    return {
+        "description": f"Non-overlapping {kind} region overlay on the "
+                       "MediaPipe-478 mesh. Winner-take-all geodesic-Voronoi "
+                       "partition of the bundled canonical mesh, walled off by "
+                       "the eye/mouth aperture rings.",
+        "kind": kind,
+        "n_regions": n,
+        "tightness": rm.TIGHTNESS,
+        "mesh": "feat/resources/canonical_face_model.pt (468 verts)",
+        "generator": "scripts/build_region_maps.py",
+        "sources": ["FACS (Ekman & Friesen)",
+                    "melindaozel.com/arkit-to-facs-cheat-sheet",
+                    "pooyadeperson.com ARKit-52 anatomy guide"],
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", default=get_resource_path())
+    args = ap.parse_args()
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    au = rm.build_au_region_map()
+    bs = rm.build_blendshape_region_map()
+
+    for name, regions, kind in (
+        (rm.AU_MAP_FILENAME, au, "AU"),
+        (rm.BLENDSHAPE_MAP_FILENAME, bs, "blendshape"),
+    ):
+        path = os.path.join(args.out_dir, name)
+        with open(path, "w") as f:
+            json.dump({"_meta": _meta(kind, len(regions)), "regions": regions},
+                      f, indent=2)
+        covered = sorted({v for r in regions.values() for v in r["mp478_vertices"]})
+        empty = [k for k, r in regions.items() if r["n_vertices"] == 0]
+        print(f"{kind:10s} regions={len(regions):3d}  verts_covered={len(covered)}/468"
+              f"  empty={empty if empty else 'NONE'}", flush=True)
+        for k, r in regions.items():
+            tag = r["au"] if "au" in r else "+".join(r["muscles"])
+            print(f"  {k:22s} {tag:10s} {r['n_vertices']:3d}v", flush=True)
+        print("wrote", path, flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds non-overlapping, L/R-symmetric **facial-region overlays** on the MediaPipe-478 mesh — the dense-mesh successor to the dlib-68 muscle polygons in `plot_face(muscles=True)`. Ships two maps (AU and ARKit-blendshape) and a renderer that works on the canonical mesh *or* a detected 478-mesh (for pyfeat-live).

## How it works

- **`feat/utils/region_maps.py`** — a winner-take-all **geodesic-Voronoi partition** of the bundled canonical mesh, walled off by the eye/mouth apertures:
  - **AU map**: 20-muscle partition merged to AU (L+R together), 19 regions.
  - **Blendshape map**: partition by *feature* (L/R seeds merged), then each sided blendshape is the half of its feature on its side of the **facial midline** (split by triangle centroid) — so left/right divide cleanly with no gap, no overlap, no shared center seam. 33 regions.
  - The partition is **mirror-symmetrized** so winner-take-all boundary noise can't make L/R asymmetric.
  - Render uses **2 levels of midpoint subdivision** for smooth boundaries; the subdivision topology + region labels are fixed in index space, so the same assets overlay a live detected mesh (only positions recompute).
- **`scripts/build_region_maps.py`** + **`feat/resources/{au,blendshape}_region_map.json`** — generator and shipped maps. Mapping grounded in FACS, the Ozel ARKit→FACS cheat sheet, and the pooyadeperson ARKit-52 anatomy guide (documented in the script/module headers).
- **`feat.plotting.plot_face_regions(values, kind, landmarks, ...)`** — render a map "key" (distinct colors) or an **intensity overlay** (colormap), on the canonical mesh or a detected 478-mesh.
- **`Fex.plot_detections(faces='au_regions' | 'blendshape_regions')`** — shade regions by a frame's detected AU / blendshape intensities (verified on a live Detectorv2 run).

## Tests

- `feat/tests/test_region_maps.py` (17 tests): schema, vertex range, aperture exclusion, strict non-overlap (both maps), exact L/R mirror symmetry, regeneration-matches-shipped, render assets, and the plotting API (map view, intensity dict/array, overlay-on-detected-mesh, bad inputs).
- `test_plot_detections` extended with the two new `faces=` modes.
- `uvx ruff` clean.

## Notes

- The existing overlapping muscle map (`muscle_to_mesh_map.json` / `muscle_to_landmark.py`) is **kept** as an anatomical reference; this adds two new maps alongside it.
- Pure lip-closure blendshapes (mouthPress/Close/Roll) share the orbicularis-oris skin with Pucker/Funnel/ShrugUpper and are represented by those regions (documented).
- Next: wire into **pyfeat-live** to replace the existing AU visualization and add the blendshape visualization for Detectorv2.