### PR TITLE
docs: deploy from main only + plot_face_regions tutorial section

### DIFF
--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -125,6 +125,10 @@ jobs:
   docs:
     name: Build & deploy docs
     runs-on: ubuntu-latest
+    # Deploy py-feat.org from main only. Tests above still run on both main and
+    # v0.7-dev, but publishing from both into the same gh-pages root made the
+    # live site flip-flop between branch states (last push wins).
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/docs/_rendered/manifest.json
+++ b/docs/_rendered/manifest.json
@@ -4,42 +4,42 @@
       "body_path": "basic_tutorials/Analysis.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T04:30:18+00:00",
+      "rendered_at": "2026-06-17T02:40:53+00:00",
       "src_hash": "e2ad580428a3028d0732f13d2d36c4510a5aa27bb0a9013fb87a5234c8718a2d"
     },
     "basic_tutorials/Detecting_Images.py": {
       "body_path": "basic_tutorials/Detecting_Images.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T02:36:31+00:00",
+      "rendered_at": "2026-06-17T02:39:38+00:00",
       "src_hash": "7dc1e1e169b53874cf0144457c53954991e265c99d921b33024dcb68536c7e1b"
     },
     "basic_tutorials/Detecting_Videos.py": {
       "body_path": "basic_tutorials/Detecting_Videos.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T02:36:51+00:00",
+      "rendered_at": "2026-06-17T02:39:59+00:00",
       "src_hash": "3eab59d5d642f94b864eedc7937a3856fb4226c544bff3e953269e2f3412431b"
     },
     "basic_tutorials/Performance.py": {
       "body_path": "basic_tutorials/Performance.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T03:32:00+00:00",
+      "rendered_at": "2026-06-17T02:41:20+00:00",
       "src_hash": "426604bc32e2edacfc3ae29dd6594898ffdcd2d98aa06a5c58ffde32cfba1cc1"
     },
     "basic_tutorials/Plotting.py": {
       "body_path": "basic_tutorials/Plotting.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T03:06:48+00:00",
-      "src_hash": "7f26fdb0ba7bf996458709d9a4350b21f530035ab5fadb9ae582064e830fd655"
+      "rendered_at": "2026-06-17T02:40:37+00:00",
+      "src_hash": "cf05fb708539a0f8aeac48d85b0719cbbc340c948725d6a31c344fe6716e8b93"
     },
     "benchmarks/Speed.py": {
       "body_path": "benchmarks/Speed.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-15T02:37:52+00:00",
+      "rendered_at": "2026-06-17T02:41:22+00:00",
       "src_hash": "76d1b6b5a8eab8475b4c9c78971afc6789b256062862f915317bdc3c0e67e63d"
     }
   },

--- a/docs/basic_tutorials/Plotting.py
+++ b/docs/basic_tutorials/Plotting.py
@@ -408,7 +408,41 @@ def _(LineCollection, device, mesh_edges, np, plt):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 3.7 Plotting a neutral (default) face with 2D landmarks
+    ## 3.7 AU & blendshape region overlays (`plot_face_regions`)
+
+    `plot_face_regions()` shades the **non-overlapping** AU or ARKit-blendshape
+    regions of the 478-mesh — the dense-mesh successor to the dlib-68 muscle
+    heatmap shown later. With no `values` it draws a "key" (every region a
+    distinct color); pass a `{region: intensity}` dict (or a 1-D array) to shade
+    each region by activation as a monochrome heatmap. `kind='au'` merges
+    left/right per AU; `kind='blendshape'` keeps the ARKit blendshapes split
+    independently Left/Right at the facial midline. It renders on the canonical
+    mesh (a legend) or, via `landmarks=`, on a detected 478-mesh (a live overlay).
+    """)
+    return
+
+
+@app.cell
+def _(plt):
+    from feat.plotting import plot_face_regions
+
+    _fig, _axes = plt.subplots(1, 3, figsize=(13, 5))
+    plot_face_regions(kind="au", ax=_axes[0], title="AU regions (L+R merged)")
+    plot_face_regions(kind="blendshape", ax=_axes[1], title="Blendshape regions (L/R split)")
+    # intensity overlay: a smile — AU12 (lip corner puller) + AU06 (cheek raiser)
+    plot_face_regions(
+        values={"AU12": 1.0, "AU06": 0.6, "AU07": 0.4}, kind="au",
+        ax=_axes[2], cmap="Reds", title="AU activation: smile",
+    )
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 3.8 Plotting a neutral (default) face with 2D landmarks
 
     Alongside the 3D mesh, py-feat includes a pre-trained PLS model that maps an
     array of AU intensities to the classic 68-pt facial landmark set. Just pass a
@@ -436,7 +470,7 @@ def _(np):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 3.8 Plotting AU activations
+    ## 3.9 Plotting AU activations
 
     Plotting facial expressions from AU activity is just as simple. Below we increase the intensity of AU1 (inner brow raiser) to 1 before passing it to `plot_face()`.
 
@@ -550,7 +584,7 @@ def _(neutral, plot_face, plt, raised_inner_brow):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 3.9 Animating facial expressions
+    ## 3.10 Animating facial expressions
 
     Py-Feat includes an `animate_face()` function which makes it easy to "morph" one facial expression into another by interpolating between AU intensities. This function generates a GIF specified by the `save` argument. You can use this function in two ways:
     1. Using the `AU` keyword argument and a single scalar value for `start` and `end`
@@ -733,7 +767,7 @@ def _(neutral, smiling):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## 3.10 Legacy: Detectorv1 plots
+    ## 3.11 Legacy: Detectorv1 plots
 
     The visualizations below depend specifically on the modular `Detectorv1`
     pipeline (the `xgb` AU model and the 68-pt dlib landmark path) rather than

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -14,8 +14,7 @@ authors:
 copyright: "2022"
 repo: https://github.com/cosanlab/py-feat
 # molab / "edit this page" / download links resolve against this branch.
-# Update to `main` at the v2.0 cutover.
-branch: v0.7-dev
+branch: main
 url: https://py-feat.org/
 logo: images/logo/pyfeat_logo_small.png
 favicon: images/logo/favicon.ico


### PR DESCRIPTION
**B** — docs deploy gated to `main` only (tests still run on both branches); `book.yml` links point at `main`. Stops the live site flip-flopping when both `main` and `v0.7-dev` push to the same gh-pages root (the `branch: v0.7-dev` cutover TODO is now done).

**C** — new `## 3.7 AU & blendshape region overlays (plot_face_regions)` section in the Plotting tutorial (region 'key' view + a smile intensity overlay), following sections renumbered; `_rendered/Plotting.md` regenerated via `marimo-book render` (only Plotting was stale).