### PR TITLE
docs: re-render Plotting tutorial for 2.0.2 per-triangle region maps

### DIFF
--- a/docs/_rendered/manifest.json
+++ b/docs/_rendered/manifest.json
@@ -32,7 +32,7 @@
       "body_path": "basic_tutorials/Plotting.md",
       "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
       "marimo_book_version": "0.1.24",
-      "rendered_at": "2026-06-17T02:40:37+00:00",
+      "rendered_at": "2026-06-18T11:14:33+00:00",
       "src_hash": "cf05fb708539a0f8aeac48d85b0719cbbc340c948725d6a31c344fe6716e8b93"
     },
     "benchmarks/Speed.py": {

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -68,6 +68,15 @@ api_docs:
 # Heavy detector tutorials render with `mode: cached`: executed once locally
 # with a GPU via `marimo-book render`, committed to _rendered/, then reused on
 # CI without executing. defaults.mode stays static for the prose pages.
+#
+# GOTCHA: cached-page staleness is keyed to the NOTEBOOK SOURCE, not to feat's
+# behaviour. `marimo-book render --check` will NOT flag a page when a feat code
+# change alters a figure but the .py source is untouched (it reports "up to
+# date"), and CI never executes cached pages — so the site silently ships the
+# old figure. Re-run `marimo-book render` and commit _rendered/ whenever a
+# cached tutorial's source OR the feat code it exercises changes. To re-render
+# just one page (skip the slow video/perf benches), flip the others to
+# `mode: static` here, render, then restore.
 
 # Auto-generated Py-feat Live changelog (pages/pyfeatlive_changelog.md).
 # Regenerate with `marimo-book sync-releases`; kept current via a


### PR DESCRIPTION
The §3.7 `plot_face_regions` figure was rendered from the cached `_rendered/`
output and still showed the old subdivision look. Cached-page staleness tracks
the notebook *source*, not feat's behaviour, so the 2.0.2 region-map change
didn't trigger a re-render — `marimo-book render --check` reports it up to date
and CI never executes cached pages, so the site silently shipped the stale figure.

- Re-rendered `basic_tutorials/Plotting.py` against 2.0.2 (scoped: only Plotting,
  others temporarily set static to skip the video/perf benches). Exactly one
  figure changed — the AU/blendshape region-overlay panel — now the per-triangle look.
- Documented the footgun in `book.yml` (re-render on feat code changes too, not
  just source edits; how to scope to one page).