### PR TITLE
docs(ci): fix py-feat.org build — decouple render cache from marimo-book version

### DIFF
--- a/.github/workflows/auto_deploy_on_release.yml
+++ b/.github/workflows/auto_deploy_on_release.yml
@@ -46,17 +46,21 @@ jobs:
       # The marimo book builds from committed _rendered/ (mode: cached) + griffe
       # reading source for the API reference, so only marimo-book is needed — no
       # feat, torch, or model downloads. Re-run `marimo-book render` + commit
-      # _rendered/ when a cached tutorial's source changes.
+      # _rendered/ when a cached tutorial's source changes (or marimo-book bumps
+      # its _RENDER_OUTPUT_VERSION). `--strict` makes a stale cache a hard build
+      # failure instead of silently executing here, where feat is absent —
+      # which would otherwise publish tracebacks. Needs marimo-book >=0.1.26,
+      # where the render signature no longer tracks the package version.
       - name: Install marimo-book
         run: |
           uv venv --python 3.13
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          uv pip install "marimo-book[api]>=0.1.24"
+          uv pip install "marimo-book[api]>=0.1.26"
 
       - name: Build book
         run: |
           cd docs
-          marimo-book build
+          marimo-book build --strict
           echo 'py-feat.org' > _site/CNAME
 
       - name: Deploy docs

--- a/.github/workflows/manual_docs.yml
+++ b/.github/workflows/manual_docs.yml
@@ -20,17 +20,21 @@ jobs:
       # The marimo book builds from committed _rendered/ (mode: cached) + griffe
       # reading source for the API reference, so only marimo-book is needed — no
       # feat, torch, or model downloads. Re-run `marimo-book render` + commit
-      # _rendered/ when a cached tutorial's source changes.
+      # _rendered/ when a cached tutorial's source changes (or marimo-book bumps
+      # its _RENDER_OUTPUT_VERSION). `--strict` makes a stale cache a hard build
+      # failure instead of silently executing here, where feat is absent —
+      # which would otherwise publish tracebacks. Needs marimo-book >=0.1.26,
+      # where the render signature no longer tracks the package version.
       - name: Install marimo-book
         run: |
           uv venv --python 3.13
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          uv pip install "marimo-book[api]>=0.1.24"
+          uv pip install "marimo-book[api]>=0.1.26"
 
       - name: Build book
         run: |
           cd docs
-          marimo-book build
+          marimo-book build --strict
           echo 'py-feat.org' > _site/CNAME
 
       - name: Deploy docs

--- a/.github/workflows/tests_and_docs.yml
+++ b/.github/workflows/tests_and_docs.yml
@@ -142,17 +142,21 @@ jobs:
       # The marimo book builds from committed _rendered/ (mode: cached) + griffe
       # reading source for the API reference, so only marimo-book is needed — no
       # feat, torch, or model downloads. Re-run `marimo-book render` + commit
-      # _rendered/ when a cached tutorial's source changes.
+      # _rendered/ when a cached tutorial's source changes (or marimo-book bumps
+      # its _RENDER_OUTPUT_VERSION). `--strict` makes a stale cache a hard build
+      # failure instead of silently executing here, where feat is absent —
+      # which would otherwise publish tracebacks. Needs marimo-book >=0.1.26,
+      # where the render signature no longer tracks the package version.
       - name: Install marimo-book
         run: |
           uv venv --python 3.13
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          uv pip install "marimo-book[api]>=0.1.24"
+          uv pip install "marimo-book[api]>=0.1.26"
 
       - name: Build book
         run: |
           cd docs
-          marimo-book build
+          marimo-book build --strict
           echo 'py-feat.org' > _site/CNAME
 
       - name: Deploy docs

--- a/.github/workflows/tests_on_pr.yml
+++ b/.github/workflows/tests_on_pr.yml
@@ -93,7 +93,13 @@ jobs:
           ruff check --ignore=W292,E402,E501,E731,E741 feat
           pytest --cov=feat -rs
 
-  # Job (3): Just build jupyter book but don't deploy it.
+  # Job (3): Build the marimo book (no deploy) to catch broken docs and a stale
+  # _rendered/ cache on PRs. Feat-free — cached pages build from committed
+  # _rendered/, so no torch/model downloads. `--strict` fails the check when a
+  # cached page is stale (source changed, or marimo-book bumped its
+  # _RENDER_OUTPUT_VERSION, without a committed `marimo-book render`) instead of
+  # letting tracebacks slip through to the deploy job. (`marimo-book render
+  # --check` is the narrower staleness-only gate if you don't want a full build.)
   docs:
     name: Build docs only
     runs-on: ubuntu-latest
@@ -101,23 +107,19 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Install uv + Python
+        uses: astral-sh/setup-uv@v6
         with:
-          # 3.12, not 3.13: jupyter-book 1.x pulls sphinx<6 whose epub3
-          # builder imports the stdlib `imghdr` module, removed in 3.13.
-          python-version: "3.12"
+          python-version: "3.13"
+          enable-cache: true
 
-      - name: Upgrade pip
+      - name: Install marimo-book
         run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
+          uv venv --python 3.13
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          uv pip install "marimo-book[api]>=0.1.26"
 
-      - name: Install deps
+      - name: Build book (strict)
         run: |
-          python3 -m pip install . -r requirements.txt
-          python3 -m pip install -r ./requirements-dev.txt
-
-      - name: Build book
-        run: |
-          jupyter-book build docs
+          cd docs
+          marimo-book build --strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,17 @@ switch them to square-pad. The square-pad crop is v2-only.
   still v0.6-era. Roadmap at
   `docs/superpowers/specs/2026-05-02-identity-detection-roadmap.md`
   (HDBSCAN, gallery-aware, tracker-based).
+- **Docs render cache (`docs/_rendered/`)**: the tutorials/benchmarks are
+  `mode: cached` in `docs/book.yml` — `marimo-book build` reuses the committed
+  `docs/_rendered/*.md` (+ `manifest.json`) and does NOT execute them, so the
+  CI deploy runs without feat/torch/GPU. **If a cached `.py` source changes,
+  re-run `marimo-book render` on a feat-equipped box and commit `_rendered/`**,
+  or the build falls back to executing (which fails in CI and ships
+  tracebacks). The `--strict` flag in the docs jobs turns a stale cache into a
+  hard failure; the PR `docs` job (`marimo-book build --strict`) is the gate.
+  Requires marimo-book >=0.1.26 — earlier versions stamped the render cache key
+  with the package *version*, so every marimo-book release silently invalidated
+  the whole cache (this is what broke py-feat.org's Plotting page).
 
 ## Roadmap (post-v0.7.0)
 

--- a/docs/_rendered/manifest.json
+++ b/docs/_rendered/manifest.json
@@ -2,43 +2,43 @@
   "entries": {
     "basic_tutorials/Analysis.py": {
       "body_path": "basic_tutorials/Analysis.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-17T02:40:53+00:00",
       "src_hash": "e2ad580428a3028d0732f13d2d36c4510a5aa27bb0a9013fb87a5234c8718a2d"
     },
     "basic_tutorials/Detecting_Images.py": {
       "body_path": "basic_tutorials/Detecting_Images.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-17T02:39:38+00:00",
       "src_hash": "7dc1e1e169b53874cf0144457c53954991e265c99d921b33024dcb68536c7e1b"
     },
     "basic_tutorials/Detecting_Videos.py": {
       "body_path": "basic_tutorials/Detecting_Videos.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-17T02:39:59+00:00",
       "src_hash": "3eab59d5d642f94b864eedc7937a3856fb4226c544bff3e953269e2f3412431b"
     },
     "basic_tutorials/Performance.py": {
       "body_path": "basic_tutorials/Performance.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-17T02:41:20+00:00",
       "src_hash": "426604bc32e2edacfc3ae29dd6594898ffdcd2d98aa06a5c58ffde32cfba1cc1"
     },
     "basic_tutorials/Plotting.py": {
       "body_path": "basic_tutorials/Plotting.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-18T11:14:33+00:00",
       "src_hash": "cf05fb708539a0f8aeac48d85b0719cbbc340c948725d6a31c344fe6716e8b93"
     },
     "benchmarks/Speed.py": {
       "body_path": "benchmarks/Speed.md",
-      "body_sig": "sha256:c6812638222d8b66c96ef47cde540314fe869cc5f61f95e72f9a72ae90c53b2c",
-      "marimo_book_version": "0.1.24",
+      "body_sig": "sha256:17c7f2864c8600e4e5eea88b4e6a304a04808ccfe569755f697e24c88547a668",
+      "marimo_book_version": "0.1.26",
       "rendered_at": "2026-06-17T02:41:22+00:00",
       "src_hash": "76d1b6b5a8eab8475b4c9c78971afc6789b256062862f915317bdc3c0e67e63d"
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,9 @@ pre-commit
 pytest
 pytest-cov
 coveralls
-sphinx<6
-sphinx-rtd-theme
-sphinxcontrib-napoleon
-jupyter-book<2
 # marimo-book docs build. The [api] extra pulls mkdocstrings+griffe for the
-# auto-generated API reference (docs/book.yml `api_docs`). Needs the release
-# that ships cached-render mode + the api_docs import-alias fix.
-marimo-book[api]>=0.1.24
+# auto-generated API reference (docs/book.yml `api_docs`). >=0.1.26 decouples
+# the committed-render cache key from the package version, so upgrading
+# marimo-book no longer forces a re-render of the heavy cached notebooks.
+marimo-book[api]>=0.1.26
 plotly>=5.6.0


### PR DESCRIPTION
## Problem

py-feat.org's Plotting tutorial shipped `ModuleNotFoundError: No module named
'numpy'`/`torch` tracebacks. The docs deploy installs **only** marimo-book (no
feat/torch) and serves the committed `docs/_rendered/` cache — but
marimo-book ≤0.1.25 keyed that cache on its own **package version**, so the
floating `>=0.1.24` pull of 0.1.25 invalidated every cached page and the build
fell back to *executing* the notebooks in a feat-less runner.

Reproduced in a clean Python 3.13 venv (marimo-book 0.1.25, no feat): build →
`0 cached`, Plotting page → 26 `ModuleNotFound` errors — exactly the live site.

## Fix (no notebook execution required)

The rendered output is byte-identical across these marimo-book versions (0.1.25
only touched `sync-releases`), so no re-render was needed:

- **Pin `marimo-book[api]>=0.1.26`** — that release decouples the render cache
  key from the package version (ljchang/marimo-book#64), so version bumps no
  longer invalidate the cache.
- **`--strict` on all three deploy builds** — a stale cache becomes a hard
  failure instead of silently executing and publishing tracebacks.
- **PR `docs` job migrated off jupyter-book** to a feat-free
  `marimo-book build --strict` — the staleness gate that would have caught this.
  Dropped the now-unused jupyter-book/sphinx dev deps.
- **Refreshed `docs/_rendered/manifest.json`** to the decoupled `body_sig`
  (computed, not executed). Verified feat-less build: 6 cached, 0 errors,
  `--strict` exit 0.
- Documented the cache/version coupling in `CLAUDE.md`.

## ⚠️ Depends on marimo-book 0.1.26

CI here stays red until **ljchang/marimo-book#64 is merged and 0.1.26 is
released to PyPI** (the `>=0.1.26` pin won't resolve before then).

## Follow-up (separate PR)

`mo.persistent_cache` for the heavy benchmark notebooks (`Performance.py`,
`Speed.py`, `Detecting_Videos.py`) — must be paired with a `marimo-book render`
on a feat/GPU box (it changes the cached `.py` sources), so it can't ride this
execution-free PR.