### PR TITLE
docs(perf): cache heavy video detect with mo.persistent_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ docs/_build/
 docs/_site/
 docs/_site_src/
 docs/.marimo_book_cache/
+# mo.persistent_cache scratch — a local re-render accelerator, not a shared
+# artifact (keys embed machine-specific values); _rendered/ is the cross-machine layer.
+docs/**/__marimo__/
 
 # PyBuilder
 target/

--- a/docs/basic_tutorials/Detecting_Videos.py
+++ b/docs/basic_tutorials/Detecting_Videos.py
@@ -84,14 +84,19 @@ def _(mo):
 
 
 @app.cell
-def _(detector, test_video_path):
+def _(detector, mo, test_video_path):
     # Without batching: one frame at a time (batch_size=1, the default).
-    video_prediction = detector.detect(
-        test_video_path,
-        data_type="video",
-        skip_frames=24,
-        face_detection_threshold=0.95,
-    )
+    # `mo.persistent_cache` memoizes the (slow) video detect to disk keyed on
+    # this block's code + inputs, so a later `marimo-book render` skips the GPU
+    # pass entirely instead of re-processing the clip. Independent of the
+    # marimo-book version, so it survives tool upgrades.
+    with mo.persistent_cache(name="video_prediction"):
+        video_prediction = detector.detect(
+            test_video_path,
+            data_type="video",
+            skip_frames=24,
+            face_detection_threshold=0.95,
+        )
     video_prediction.head()
     return (video_prediction,)
 
@@ -121,16 +126,19 @@ def _(mo):
 
 
 @app.cell
-def _(detector, test_video_path):
+def _(detector, mo, test_video_path):
     # With batching: 8 frames per forward pass — much faster on a GPU.
     # On CUDA, pin_memory=True further speeds host->device transfers.
-    video_prediction_batched = detector.detect(
-        test_video_path,
-        data_type="video",
-        batch_size=8,
-        skip_frames=24,
-        face_detection_threshold=0.95,
-    )
+    # Cached the same way as the unbatched detect above, so a re-render reuses
+    # the result instead of re-processing the clip.
+    with mo.persistent_cache(name="video_prediction_batched"):
+        video_prediction_batched = detector.detect(
+            test_video_path,
+            data_type="video",
+            batch_size=8,
+            skip_frames=24,
+            face_detection_threshold=0.95,
+        )
     video_prediction_batched.shape
     return
 


### PR DESCRIPTION
**Draft — needs a `marimo-book render` before it can merge (see below).**
Replaces #362, which GitHub auto-closed when its base branch (#361) was merged
and deleted.

## What

Wraps the two `detector.detect(..., data_type="video")` calls in
`Detecting_Videos.py` in `mo.persistent_cache`, so re-rendering reuses the
result from disk instead of reprocessing the clip.

## Scope: same-machine accelerator only

Not a shared/CI cache. marimo keys the cache on the block's code + its
ancestors' *values* (absolute test-data paths, the `detector` object), which
differ per machine — so hits don't reliably transfer across computers. The
committed `docs/_rendered/` remains the cross-machine layer. `__marimo__/` is
gitignored; we are not committing cache artifacts. The durable
"don't re-run on every marimo-book release" win is the cache-key decoupling
already shipped in marimo-book 0.1.26 (#361), not this.

## ⚠️ Required before merge

Editing the cached notebook changes its `src_hash`, so `docs/_rendered/` is now
stale and `--strict` CI will fail until you:

```
# on a feat/GPU box, with marimo-book>=0.1.26
cd docs && marimo-book render
git add docs/_rendered && git commit -m "docs: re-render Detecting_Videos for persistent_cache"
```

Only `Detecting_Videos.py` is wrapped — `Speed.py` reads precomputed JSON and
`Performance.py` is a timing tutorial (caching defeats the measurement).