### PR TITLE
fix(docs): render the sidebar logo (SVG needed explicit width/height)

### DIFF
--- a/docs/images/logo/pyfeat_logo_green.svg
+++ b/docs/images/logo/pyfeat_logo_green.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 741.68 741.68">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="741.68" height="741.68" viewBox="0 0 741.68 741.68">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
## Problem
After switching the book logo to `pyfeat_logo_green.svg`, the logo disappeared on the deployed site.

## Root cause
The sidebar/header logo is an `<img>` inside a flex container, sized by `logo_sidebar.css` with `width:auto; height:auto; max-height:96px`. The SVG had only a `viewBox` and no `width`/`height` attributes, so in that flex layout the image had no intrinsic size and collapsed to **0×0**. (The asset itself loaded fine — HTTP 200 — it just rendered invisibly.)

Verified in the live DOM with a headless browser: the shipped SVG rendered 0×0; the same SVG with `width`/`height` added rendered 96×96.

## Fix
Add `width="741.68" height="741.68"` (matching the viewBox) to the `<svg>` root. Stays vector/transparent; the existing CSS scales it down to 96px.