### PR TITLE
Add Apple M5 Max CPU+MPS benchmarks (v1 + v2); fix image-section fps parsing

### DIFF
--- a/docs/benchmarks/2026-06-22-788e6d8.md
+++ b/docs/benchmarks/2026-06-22-788e6d8.md
@@ -1,0 +1,183 @@
+# py-feat detector benchmark — 2026-06-22 16:49:39
+
+## Run metadata
+
+- **Date:** 2026-06-22 16:49:39
+- **py-feat version:** 2.0.2
+- **Git commit:** 788e6d8
+- **Host:** m5max (arm64, 18 CPUs)
+- **Python:** 3.13.12
+- **PyTorch:** 2.11.0
+- **GPU:** Apple M5 Max (MPS)
+- **OMP_NUM_THREADS:** `1`
+- **Devices swept:** ['cpu', 'mps']
+- **Batch sizes:** [1, 4, 16]
+- **DataLoader workers:** [0]
+
+Each timed call is preceded by one untimed warmup; the timed-call wall time is reported.
+
+## Video: short (72 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 27.52 | 382.2 | 2.6 |
+| cpu | 4 | 26.91 | 373.8 | 2.7 |
+| cpu | 16 | 107.46 | 1492.5 | 0.7 |
+| mps | 1 | 7.90 | 109.7 | 9.1 |
+| mps | 4 | 5.63 | 78.2 | 12.8 |
+| mps | 16 | 5.34 | 74.1 | 13.5 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 13.91 | 193.2 | 5.2 |
+| cpu | 4 | 13.24 | 183.9 | 5.4 |
+| cpu | 16 | 74.70 | 1037.5 | 1.0 |
+| mps | 1 | 3.73 | 51.9 | 19.3 |
+| mps | 4 | 1.51 | 21.0 | 47.6 |
+| mps | 16 | 1.00 | 13.9 | 71.9 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 31.91 | 443.2 | 2.3 |
+| cpu | 4 | 29.45 | 409.0 | 2.4 |
+| cpu | 16 | 36.05 | 500.7 | 2.0 |
+| mps | 1 | 2.22 | 30.8 | 32.5 |
+| mps | 4 | 0.77 | 10.7 | 93.5 |
+| mps | 16 | 0.54 | 7.4 | 134.3 |
+
+
+## Video: long (472 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| mps | 1 | 60.77 | 128.7 | 7.8 |
+| mps | 4 | 44.73 | 94.8 | 10.6 |
+| mps | 16 | 42.03 | 89.0 | 11.2 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 88.73 | 188.0 | 5.3 |
+| cpu | 4 | 85.13 | 180.4 | 5.5 |
+| cpu | 16 | 537.09 | 1137.9 | 0.9 |
+| mps | 1 | 24.75 | 52.4 | 19.1 |
+| mps | 4 | 10.61 | 22.5 | 44.5 |
+| mps | 16 | 6.45 | 13.7 | 73.2 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 205.84 | 436.1 | 2.3 |
+| cpu | 4 | 193.92 | 410.8 | 2.4 |
+| cpu | 16 | 238.38 | 505.0 | 2.0 |
+| mps | 1 | 15.69 | 33.2 | 30.1 |
+| mps | 4 | 5.44 | 11.5 | 86.7 |
+| mps | 16 | 3.67 | 7.8 | 128.5 |
+
+
+## Images: 16 x multi_face.jpg = 80 faces
+
+### img2pose
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 13.26 | 829.0 | 80 |
+| cpu | 4 | 67.18 | 4198.8 | 80 |
+| cpu | 16 | 64.01 | 4000.4 | 80 |
+| mps | 1 | 2.74 | 171.4 | 80 |
+| mps | 4 | 2.20 | 137.5 | 80 |
+| mps | 16 | 2.31 | 144.1 | 80 |
+
+
+### retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 12.17 | 760.9 | 80 |
+| cpu | 4 | 66.15 | 4134.2 | 80 |
+| cpu | 16 | 64.35 | 4021.8 | 80 |
+| mps | 1 | 1.34 | 83.8 | 80 |
+| mps | 4 | 0.85 | 53.4 | 80 |
+| mps | 16 | 0.96 | 60.3 | 80 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 29.61 | 1850.6 | 80 |
+| cpu | 4 | 17.93 | 1120.8 | 80 |
+| cpu | 16 | 24.38 | 1524.0 | 80 |
+| mps | 1 | 0.75 | 46.8 | 80 |
+| mps | 4 | 0.51 | 31.9 | 80 |
+| mps | 16 | 0.52 | 32.2 | 80 |
+
+---
+
+## M5 Max narrative — CPU vs MPS, v1 vs v2
+
+Hardware: **Apple M5 Max** (18 cores: 6 efficiency + 12 performance, 128 GB
+unified memory), macOS 26, Python 3.13.12, PyTorch 2.11.0, py-feat 2.0.2,
+`OMP_NUM_THREADS=1`. Configs run: **Detectorv1** (`img2pose` and `retinaface`
+face models) and **Detectorv2** (multitask). MPDetector was excluded from this
+run. Headline numbers are from the sustained 472-frame long-video path; the
+short-video and image sweeps agree on the rankings.
+
+### Headline (long video, 472 frames, batch 16, MPS)
+
+| config | ms/frame | fps |
+|---|---|---|
+| **Detectorv2 multitask** | **7.8** | **128.5** |
+| Detectorv1 retinaface | 13.7 | 73.2 |
+| Detectorv1 img2pose | 89.0 | 11.2 |
+
+**Detectorv2 on MPS is the throughput champion** — ~1.8× faster than the best v1
+config (retinaface) and ~11× faster than v1/img2pose. The v2 multitask head folds
+detection + landmarks + AUs + pose into one forward pass, so it amortizes far
+better than v1's staged pipeline.
+
+### Findings
+
+- **Use MPS on Apple Silicon — there is no CPU crossover.** MPS wins at *every*
+  batch size and config, including batch 1, where MPS launch overhead usually
+  lets CPU stay competitive. At batch 1 (short video) MPS is 3.5× faster for
+  img2pose, 3.7× for retinaface, and **14× for Detectorv2** (30.8 vs 443.2
+  ms/frame). The M5 Max's unified memory makes host↔device transfer cheap enough
+  that small batches still favor the GPU.
+- **MPS scales with batch size; CPU degrades.** On MPS, retinaface goes 51.9 →
+  21.0 → 13.9 ms/frame (batch 1 → 4 → 16) and v2 goes 30.8 → 10.7 → 7.4. On CPU
+  the v1 configs get *slower* with larger batches — v1/img2pose long-video CPU is
+  188 ms/frame at batch 1 but **1138 ms/frame at batch 16** (~6× worse), and the
+  image sweep shows the same blow-up (829 → 4199 ms/img). Under the forced
+  `OMP_NUM_THREADS=1`, v1's per-frame multi-stage loop (HOG → xgb) thrashes on
+  large CPU batches. **On CPU, keep `batch_size=1`.**
+- **v2 is the most CPU-robust config**, even though CPU is never the right choice
+  on this machine. v2 CPU stays ~440–505 ms/frame across all batch sizes (single
+  fused forward pass, no per-frame staging), versus v1's batch-size cliff. If a
+  user is stuck on CPU-only hardware, v2 at batch 1 is the most predictable.
+- **Within v1, retinaface beats img2pose** by ~3.7× on MPS at batch 16 (13.7 vs
+  89.0 ms/frame). img2pose carries a heavier detector backbone; retinaface is the
+  faster v1 face model whenever pose-from-img2pose isn't specifically required.
+
+### Reproduce
+
+```bash
+# This run (v1 + v2 only, both devices); MPDetector was temporarily removed
+# from CONFIGS for this sweep, then restored. The script default runs all four.
+python scripts/bench_detectors.py --devices cpu mps --markdown
+```
+

--- a/docs/benchmarks/speed-clean-m5max.md
+++ b/docs/benchmarks/speed-clean-m5max.md
@@ -1,0 +1,128 @@
+# py-feat detector benchmark — 2026-06-22 16:49:39
+
+## Run metadata
+
+- **Date:** 2026-06-22 16:49:39
+- **py-feat version:** 2.0.2
+- **Git commit:** 788e6d8
+- **Host:** m5max (arm64, 18 CPUs)
+- **Python:** 3.13.12
+- **PyTorch:** 2.11.0
+- **GPU:** Apple M5 Max (MPS)
+- **OMP_NUM_THREADS:** `1`
+- **Devices swept:** ['cpu', 'mps']
+- **Batch sizes:** [1, 4, 16]
+- **DataLoader workers:** [0]
+
+Each timed call is preceded by one untimed warmup; the timed-call wall time is reported.
+
+## Video: short (72 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 27.52 | 382.2 | 2.6 |
+| cpu | 4 | 26.91 | 373.8 | 2.7 |
+| cpu | 16 | 107.46 | 1492.5 | 0.7 |
+| mps | 1 | 7.90 | 109.7 | 9.1 |
+| mps | 4 | 5.63 | 78.2 | 12.8 |
+| mps | 16 | 5.34 | 74.1 | 13.5 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 13.91 | 193.2 | 5.2 |
+| cpu | 4 | 13.24 | 183.9 | 5.4 |
+| cpu | 16 | 74.70 | 1037.5 | 1.0 |
+| mps | 1 | 3.73 | 51.9 | 19.3 |
+| mps | 4 | 1.51 | 21.0 | 47.6 |
+| mps | 16 | 1.00 | 13.9 | 71.9 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 31.91 | 443.2 | 2.3 |
+| cpu | 4 | 29.45 | 409.0 | 2.4 |
+| cpu | 16 | 36.05 | 500.7 | 2.0 |
+| mps | 1 | 2.22 | 30.8 | 32.5 |
+| mps | 4 | 0.77 | 10.7 | 93.5 |
+| mps | 16 | 0.54 | 7.4 | 134.3 |
+
+
+## Video: long (472 frames)
+
+### img2pose
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| mps | 1 | 60.77 | 128.7 | 7.8 |
+| mps | 4 | 44.73 | 94.8 | 10.6 |
+| mps | 16 | 42.03 | 89.0 | 11.2 |
+
+
+### retinaface
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 88.73 | 188.0 | 5.3 |
+| cpu | 4 | 85.13 | 180.4 | 5.5 |
+| cpu | 16 | 537.09 | 1137.9 | 0.9 |
+| mps | 1 | 24.75 | 52.4 | 19.1 |
+| mps | 4 | 10.61 | 22.5 | 44.5 |
+| mps | 16 | 6.45 | 13.7 | 73.2 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/frame | fps |
+|---|---|---|---|---|
+| cpu | 1 | 205.84 | 436.1 | 2.3 |
+| cpu | 4 | 193.92 | 410.8 | 2.4 |
+| cpu | 16 | 238.38 | 505.0 | 2.0 |
+| mps | 1 | 15.69 | 33.2 | 30.1 |
+| mps | 4 | 5.44 | 11.5 | 86.7 |
+| mps | 16 | 3.67 | 7.8 | 128.5 |
+
+
+## Images: 16 x multi_face.jpg = 80 faces
+
+### img2pose
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 13.26 | 829.0 | 80 |
+| cpu | 4 | 67.18 | 4198.8 | 80 |
+| cpu | 16 | 64.01 | 4000.4 | 80 |
+| mps | 1 | 2.74 | 171.4 | 80 |
+| mps | 4 | 2.20 | 137.5 | 80 |
+| mps | 16 | 2.31 | 144.1 | 80 |
+
+
+### retinaface
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 12.17 | 760.9 | 80 |
+| cpu | 4 | 66.15 | 4134.2 | 80 |
+| cpu | 16 | 64.35 | 4021.8 | 80 |
+| mps | 1 | 1.34 | 83.8 | 80 |
+| mps | 4 | 0.85 | 53.4 | 80 |
+| mps | 16 | 0.96 | 60.3 | 80 |
+
+
+### Detectorv2 multitask
+
+| device | batch | sec | ms/img | rows |
+|---|---|---|---|---|
+| cpu | 1 | 29.61 | 1850.6 | 80 |
+| cpu | 4 | 17.93 | 1120.8 | 80 |
+| cpu | 16 | 24.38 | 1524.0 | 80 |
+| mps | 1 | 0.75 | 46.8 | 80 |
+| mps | 4 | 0.51 | 31.9 | 80 |
+| mps | 16 | 0.52 | 32.2 | 80 |
+

--- a/docs/benchmarks/throughput.csv
+++ b/docs/benchmarks/throughput.csv
@@ -15,14 +15,14 @@ feat_version,date,host,gpu,config,device,batch,section_kind,section_label,fps
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",MPDetector retinaface,cuda,16,video,long,141.8
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,1,video,long,37.6
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,16,video,long,355.5
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",img2pose,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",img2pose,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",MPDetector retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",MPDetector retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",img2pose,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,7.3
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",img2pose,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,16.1
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,16.1
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,32.7
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",MPDetector retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,19.8
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",MPDetector retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,11.8
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,31.1
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA RTX PRO 6000 Blackwell Workstation Edition",Detectorv2 multitask,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,90.9
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,1,video,short,14.2
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,16,video,short,30.0
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",retinaface,cuda,1,video,short,21.0
@@ -39,14 +39,14 @@ feat_version,date,host,gpu,config,device,batch,section_kind,section_label,fps
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",MPDetector retinaface,cuda,16,video,long,88.1
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,1,video,long,37.9
 0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,16,video,long,202.5
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",MPDetector retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",MPDetector retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,80.0
-0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,80.0
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,8.4
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",img2pose,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,12.5
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,13.7
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,19.6
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",MPDetector retinaface,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,15.8
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",MPDetector retinaface,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,10.7
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,1,images,Images: 16 x multi_face.jpg = 80 faces,27.0
+0.7.0,2026-06-05,liquidswords2,"CUDA 12.8, NVIDIA GeForce RTX 3090",Detectorv2 multitask,cuda,16,images,Images: 16 x multi_face.jpg = 80 faces,52.1
 0.7.0,2026-06-05,liquidswords2,CPU,img2pose,cpu,1,video,short,1.6
 0.7.0,2026-06-05,liquidswords2,CPU,img2pose,cpu,16,video,short,1.8
 0.7.0,2026-06-05,liquidswords2,CPU,retinaface,cpu,1,video,short,4.3
@@ -63,3 +63,54 @@ feat_version,date,host,gpu,config,device,batch,section_kind,section_label,fps
 0.7.0,2026-06-05,liquidswords2,CPU,MPDetector retinaface,cpu,16,video,long,14.0
 0.7.0,2026-06-05,liquidswords2,CPU,Detectorv2 multitask,cpu,1,video,long,8.9
 0.7.0,2026-06-05,liquidswords2,CPU,Detectorv2 multitask,cpu,16,video,long,17.6
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,1,video,short,2.6
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,4,video,short,2.7
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,16,video,short,0.7
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,1,video,short,9.1
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,4,video,short,12.8
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,16,video,short,13.5
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,1,video,short,5.2
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,4,video,short,5.4
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,16,video,short,1.0
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,1,video,short,19.3
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,4,video,short,47.6
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,16,video,short,71.9
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,1,video,short,2.3
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,4,video,short,2.4
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,16,video,short,2.0
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,1,video,short,32.5
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,4,video,short,93.5
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,16,video,short,134.3
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,1,video,long,7.8
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,4,video,long,10.6
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,16,video,long,11.2
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,1,video,long,5.3
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,4,video,long,5.5
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,16,video,long,0.9
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,1,video,long,19.1
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,4,video,long,44.5
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,16,video,long,73.2
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,1,video,long,2.3
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,4,video,long,2.4
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,16,video,long,2.0
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,1,video,long,30.1
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,4,video,long,86.7
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,16,video,long,128.5
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,1,images,Images: 16 x multi_face.jpg = 80 faces,1.2
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,4,images,Images: 16 x multi_face.jpg = 80 faces,0.2
+2.0.2,2026-06-22,m5max,CPU,img2pose,cpu,16,images,Images: 16 x multi_face.jpg = 80 faces,0.2
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,1,images,Images: 16 x multi_face.jpg = 80 faces,5.8
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,4,images,Images: 16 x multi_face.jpg = 80 faces,7.3
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),img2pose,mps,16,images,Images: 16 x multi_face.jpg = 80 faces,6.9
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,1,images,Images: 16 x multi_face.jpg = 80 faces,1.3
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,4,images,Images: 16 x multi_face.jpg = 80 faces,0.2
+2.0.2,2026-06-22,m5max,CPU,retinaface,cpu,16,images,Images: 16 x multi_face.jpg = 80 faces,0.2
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,1,images,Images: 16 x multi_face.jpg = 80 faces,11.9
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,4,images,Images: 16 x multi_face.jpg = 80 faces,18.7
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),retinaface,mps,16,images,Images: 16 x multi_face.jpg = 80 faces,16.6
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,1,images,Images: 16 x multi_face.jpg = 80 faces,0.5
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,4,images,Images: 16 x multi_face.jpg = 80 faces,0.9
+2.0.2,2026-06-22,m5max,CPU,Detectorv2 multitask,cpu,16,images,Images: 16 x multi_face.jpg = 80 faces,0.7
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,1,images,Images: 16 x multi_face.jpg = 80 faces,21.4
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,4,images,Images: 16 x multi_face.jpg = 80 faces,31.3
+2.0.2,2026-06-22,m5max,Apple M5 Max (MPS),Detectorv2 multitask,mps,16,images,Images: 16 x multi_face.jpg = 80 faces,31.1

--- a/scripts/benchmarks_md_to_csv.py
+++ b/scripts/benchmarks_md_to_csv.py
@@ -68,13 +68,16 @@ def parse_file(path):
             config = KNOWN_CONFIGS.get(line[4:].strip())
         elif line.startswith("|") and kind and config:
             cells = [c.strip() for c in line.strip().strip("|").split("|")]
-            # expect: device | batch | sec | ms/frame | fps
+            # video: device | batch | sec | ms/frame | fps
+            # images: device | batch | sec | ms/img | rows  (no fps column;
+            #         the last cell is a face count, so derive images/sec
+            #         from the ms/img column instead).
             if len(cells) < 5 or cells[0] not in DEVICES:
                 continue
             try:
                 batch = int(cells[1])
-                fps = float(cells[-1])
-            except ValueError:
+                fps = float(cells[-1]) if kind == "video" else round(1000.0 / float(cells[3]), 1)
+            except (ValueError, ZeroDivisionError):
                 continue
             device = cells[0]
             # The GPU metadata names the *visible* device; CPU rows aren't on it.


### PR DESCRIPTION
## What

Adds a benchmark run on the **Apple M5 Max** (18-core, 128 GB) covering **CPU and MPS** for **Detectorv1** (`img2pose`, `retinaface`) and **Detectorv2 multitask**. MPDetector was excluded from this run.

Generated with the in-repo `scripts/bench_detectors.py --devices cpu mps --markdown` (no external suite).

### Files
- `docs/benchmarks/speed-clean-m5max.md` — clean tables; this is what `benchmarks_md_to_csv.py` ingests for the live dashboard.
- `docs/benchmarks/2026-06-22-788e6d8.md` — dated history run-dump + hand-curated M5 Max narrative (headline numbers, CPU-vs-MPS, v1-vs-v2).
- `docs/benchmarks/throughput.csv` — regenerated (adds the M5 rows; see fix below).
- `scripts/benchmarks_md_to_csv.py` — parser bugfix.

## Headline (472-frame video, MPS, batch 16)

| config | ms/frame | fps |
|---|---|---|
| **Detectorv2 multitask** | **7.8** | **128.5** |
| Detectorv1 retinaface | 13.7 | 73.2 |
| Detectorv1 img2pose | 89.0 | 11.2 |

- On the M5 Max, **MPS wins at every batch size and config — no CPU crossover**; v2 is ~14× faster than CPU even at batch 1.
- **CPU batching is pathological for v1** (img2pose long-video CPU degrades ~6× from batch 1 → 16 under `OMP_NUM_THREADS=1`), but flat for v2. Keep `batch_size=1` on CPU.
- **Detectorv2 on MPS is the throughput champion** — ~1.8× faster than the best v1 config.

## Bugfix: image-section fps parsing

`benchmarks_md_to_csv.py` assumed every table's last column is `fps`, but **image tables end in a face-count column** (`device | batch | sec | ms/img | rows`). Result: every image row across **all hosts** was recording `fps=80.0` (the face count). Fixed by deriving images/sec from the `ms/img` column for image sections. This also corrects the pre-existing blackwell/3090 image rows in `throughput.csv`.

## Notes
- This feeds the committed-`throughput.csv` dashboard path only; the `py-feat/benchmarks` HF dataset (via `ingest_benchmarks.py --json`) is a separate pipeline and is **not** updated here (needs an HF write token).