### PR TITLE
Fix Detectorv2 chip crop on MPS (grid_sample reflection → border)

### DIFF
--- a/feat/utils/image_operations.py
+++ b/feat/utils/image_operations.py
@@ -1314,9 +1314,12 @@ def extract_face_square_pad_torch(
 
     # reflection padding: off-frame square regions sample mirrored interior pixels
     # (vs the legacy default 'zeros'), so the GAP-pooled chip isn't diluted by
-    # black borders at frame edges.
+    # black borders at frame edges. MPS has no grid_sample reflection kernel, so
+    # use 'border' there — identical for in-frame crops, edge-replicate vs mirror
+    # only where the bbox runs off-frame.
+    pad_mode = "border" if frame_expanded.device.type == "mps" else "reflection"
     cropped_faces = F.grid_sample(
-        frame_expanded, grid, padding_mode="reflection", align_corners=False
+        frame_expanded, grid, padding_mode=pad_mode, align_corners=False
     )
     return cropped_faces, crop_affine
 


### PR DESCRIPTION
## Problem
`extract_face_square_pad_torch` (the v2.5 square-pad crop used by `Detectorv2`) calls `F.grid_sample(..., padding_mode="reflection")`. MPS has no reflection kernel for `grid_sample`, so Detectorv2 face cropping raises on Apple Silicon.

## Fix
Use `padding_mode="border"` on MPS only; CUDA/CPU keep `reflection` unchanged.

`border` is **identical to `reflection` for any in-frame crop** — when no sample falls outside the frame, every padding mode returns the same pixels (verified: max abs diff 0.0 for in-frame grids). They differ only where the face bbox runs off the frame edge, where both are just approximations of missing pixels (edge-replicate vs mirror).

## Scope
One-line device guard; no change to the CUDA/CPU path. Unblocks running `Detectorv2` (and the full RetinaFace→crop→multitask path) on MPS.